### PR TITLE
feat: add global layout header and footer

### DIFF
--- a/app-next-directory/app/layout.tsx
+++ b/app-next-directory/app/layout.tsx
@@ -31,7 +31,6 @@ export default function RootLayout({ children }: { readonly children: React.Reac
           <main id="main-content" tabIndex={-1} className="pt-16">
             {children}
           </main>
-          <Footer />
         </ClientRootLayout>
       </body>
     </html>

--- a/app-next-directory/app/layout.tsx
+++ b/app-next-directory/app/layout.tsx
@@ -11,7 +11,8 @@ export const metadata: Metadata = {
 };
 import "./globals.css";
 import { TwentyFirstToolbar } from '@21st-extension/toolbar-next';
-import { MainNav } from '@/components/layout/MainNav';
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
 import ClientRootLayout from './ClientRootLayout';
 
 export default function RootLayout({ children }: { readonly children: React.ReactNode }) {
@@ -26,10 +27,11 @@ export default function RootLayout({ children }: { readonly children: React.Reac
             Skip to main content
           </a>
           <TwentyFirstToolbar config={{ plugins: [] }} />
-          <MainNav />
+          <Header />
           <main id="main-content" tabIndex={-1} className="pt-16">
             {children}
           </main>
+          <Footer />
         </ClientRootLayout>
       </body>
     </html>

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import React from 'react';
+
+export default function Header() {
+  return (
+    <header className="bg-white shadow">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+        <Link href="/" className="text-xl font-bold">
+          Sustainable Nomads
+        </Link>
+        <nav className="space-x-4">
+          <Link href="/listings" className="hover:underline">
+            Listings
+          </Link>
+          <Link href="/blog" className="hover:underline">
+            Blog
+          </Link>
+          <Link href="/about" className="hover:underline">
+            About
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap app layout with new Header and Footer components for consistent site chrome
- add simple Header with logo and basic navigation

## Testing
- `pnpm --filter ./app-next-directory lint` *(fails: app-next-directory@0.1.0 lint: `next lint`)*
- `pnpm --filter ./app-next-directory typecheck` *(fails: app/search/page.tsx unexpected token)*
- `pnpm --filter ./app-next-directory test` *(fails: Could not locate module leaflet/dist/leaflet.css)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6ff17b48323809094f36f8477c0