### PR TITLE
fix: build listing card links from slug

### DIFF
--- a/app-next-directory/src/components/listings/ListingCard.tsx
+++ b/app-next-directory/src/components/listings/ListingCard.tsx
@@ -12,8 +12,7 @@ export interface ListingCardProps {
 }
 
 const getListingUrl = (listing: AppListingCard) => {
-  const slug = listing.slug ?? listing.id;
-  return `/listings/${slug}`;
+  return listing.slug ? `/listings/${listing.slug}` : '#';
 };
 
 export function ListingCard({ listing, searchQuery }: ListingCardProps) {


### PR DESCRIPTION
## Summary
- ensure listing card link uses slug if available

## Testing
- `pnpm --filter ./app-next-directory run typecheck` *(fails: app/search/page.tsx unexpected token)*
- `pnpm --filter ./app-next-directory exec jest` *(fails: Could not locate module leaflet/dist/leaflet.css)*
- `pnpm --filter ./app-next-directory lint`


------
https://chatgpt.com/codex/tasks/task_e_68a865c50fd88323a9ed57c4c924107d