### PR TITLE
Use slugs for listing and city navigation

### DIFF
--- a/app-next-directory/src/components/cities/CitiesSection.tsx
+++ b/app-next-directory/src/components/cities/CitiesSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 
 interface City {
   id: string;
@@ -50,7 +51,11 @@ export default function CitiesSection() {
         <h2 className="text-3xl font-bold mb-10 text-center text-green-900">Eco-Friendly Cities</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
           {cities.map(city => (
-            <div key={city.id} className="bg-white rounded-lg shadow-lg overflow-hidden flex flex-col">
+            <Link
+              key={city.id}
+              href={`/city/${city.slug}`}
+              className="bg-white rounded-lg shadow-lg overflow-hidden flex flex-col hover:shadow-xl transition-shadow"
+            >
               <div className="relative w-full h-48">
                 {city.primaryImage ? (
                   <Image
@@ -82,7 +87,7 @@ export default function CitiesSection() {
                   <span className="text-lg font-bold text-green-600">{city.sustainabilityScore}</span>
                 </div>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       </div>

--- a/app-next-directory/src/components/listings/ListingCard.test.tsx
+++ b/app-next-directory/src/components/listings/ListingCard.test.tsx
@@ -191,13 +191,13 @@ describe('ListingCard', () => {
     expect(link).toHaveAttribute('href', '/listings/non-sanity-test-slug');
   });
 
-  test('getListingUrl returns default slug for missing slug', () => {
-    const listingWithoutSlug: AppListingCard = { 
-      ...mockListing, 
-      slug: 'default-slug' 
+  test('getListingUrl falls back to # when slug is missing', () => {
+    const listingWithoutSlug: AppListingCard = {
+      ...mockListing,
+      slug: undefined,
     };
     render(<ListingCard listing={listingWithoutSlug} />);
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/listings/default-slug');
+    expect(screen.getByRole('link')).toHaveAttribute('href', '#');
   });
 
   test('image URL is correct for primaryImage', () => {

--- a/app-next-directory/src/components/listings/ListingCard.tsx
+++ b/app-next-directory/src/components/listings/ListingCard.tsx
@@ -12,8 +12,7 @@ export interface ListingCardProps {
 }
 
 const getListingUrl = (listing: AppListingCard) => {
-  const slug = listing.slug ?? listing.id;
-  return `/listings/${slug}`;
+  return listing.slug ? `/listings/${listing.slug}` : '#';
 };
 
 export function ListingCard({ listing, searchQuery }: ListingCardProps) {


### PR DESCRIPTION
## Summary
- build listing URLs from slug with fallback to '#'
- make city cards link to `/city/[slug]`
- update ListingCard tests for slug-only navigation

## Testing
- `npm test` *(fails: Could not locate module leaflet/dist/leaflet.css)*
- `pnpm --filter app-next-directory lint`
- `pnpm --filter app-next-directory exec tsc --noEmit` *(fails: sanity.types.ts(801,2): error TS1005)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a95911f0408323a2a14b6e6d50ca95