### PR TITLE
feat: add city detail page with listing grid

### DIFF
--- a/app-next-directory/app/city/[slug]/page.tsx
+++ b/app-next-directory/app/city/[slug]/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CityDetailView } from '@/components/city/CityDetailView';
+import { mockCity, mockCityListings } from '@/components/city/cityDetailMockData';
+import type { CityDTO, ListingSummaryDTO } from '@/types/dto';
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function CityPage({ params }: Props) {
+  const { slug } = params;
+  const [city, setCity] = useState<CityDTO | null>(null);
+  const [listings, setListings] = useState<ListingSummaryDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await new Promise((res) => setTimeout(res, 500));
+        if (slug !== mockCity.slug) {
+          setError('City not found');
+          return;
+        }
+        setCity(mockCity);
+        setListings(mockCityListings);
+      } catch {
+        setError('Failed to fetch city');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <p className="body-lg text-neo-text-secondary">Loading city details...</p>
+      </div>
+    );
+  }
+
+  if (error || !city) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <p className="body-lg text-red-500">{error || 'City not found'}</p>
+      </div>
+    );
+  }
+
+  return <CityDetailView city={city} listings={listings} />;
+}

--- a/app-next-directory/src/components/city/CityDetailView.tsx
+++ b/app-next-directory/src/components/city/CityDetailView.tsx
@@ -1,0 +1,42 @@
+import { Leaf, MapPin } from 'lucide-react';
+import { NeoBadge } from '@/components/ui/neo-badge';
+import type { CityDTO, ListingSummaryDTO } from '@/types/dto';
+import { ListingGrid } from '@/components/listings/ListingGrid';
+
+interface CityDetailViewProps {
+  city: CityDTO;
+  listings: ListingSummaryDTO[];
+}
+
+export function CityDetailView({ city, listings }: CityDetailViewProps) {
+  return (
+    <section className="py-16 bg-background">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-3">
+            <MapPin className="text-neo-primary" />
+            <h1 className="heading-lg">{city.name}</h1>
+            {city.sustainabilityScore && (
+              <NeoBadge variant="success" className="flex items-center gap-1 ml-2">
+                <Leaf size={16} />
+                <span>{city.sustainabilityScore}%</span>
+              </NeoBadge>
+            )}
+          </div>
+        </div>
+
+        {city.highlights && city.highlights.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-12">
+            {city.highlights.map((highlight, idx) => (
+              <NeoBadge key={idx} variant="outline" size="sm">
+                {highlight}
+              </NeoBadge>
+            ))}
+          </div>
+        )}
+
+        <ListingGrid listings={listings} />
+      </div>
+    </section>
+  );
+}

--- a/app-next-directory/src/components/city/cityDetailMockData.ts
+++ b/app-next-directory/src/components/city/cityDetailMockData.ts
@@ -1,0 +1,44 @@
+import type { CityDTO, ListingSummaryDTO } from '@/types/dto';
+
+export const mockCity: CityDTO = {
+  id: 'bangkok',
+  name: 'Bangkok',
+  slug: 'bangkok',
+  country: 'Thailand',
+  sustainabilityScore: 72,
+  highlights: ['Green rooftops', 'Bike lanes', 'River taxis'],
+  imageUrl:
+    'https://images.unsplash.com/photo-1506973035872-a4ec16b8e8d9?auto=format&fit=crop&w=800&q=80',
+  description: 'A vibrant city embracing sustainability initiatives.',
+};
+
+export const mockCityListings: ListingSummaryDTO[] = [
+  {
+    id: 'green-cowork-bangkok',
+    name: 'Green Cowork Bangkok',
+    slug: 'green-cowork-bangkok',
+    type: 'coworking',
+    city: mockCity,
+    imageUrl:
+      'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80',
+    ecoFocusTags: ['Solar Powered', 'Recycling'],
+    digitalNomadFeatures: ['Fast WiFi', 'Ergonomic Chairs'],
+    priceRange: 'moderate',
+    website: 'https://example.com',
+    address: '123 Eco Street, Bangkok',
+  },
+  {
+    id: 'eco-cafe-bangkok',
+    name: 'Eco Cafe Bangkok',
+    slug: 'eco-cafe-bangkok',
+    type: 'cafe',
+    city: mockCity,
+    imageUrl:
+      'https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=80',
+    ecoFocusTags: ['Organic', 'Zero Waste'],
+    digitalNomadFeatures: ['Power Outlets', 'Quiet Corners'],
+    priceRange: 'budget',
+    website: 'https://example.com',
+    address: '456 Green Ave, Bangkok',
+  },
+];

--- a/app-next-directory/src/components/listings/ListingGrid.tsx
+++ b/app-next-directory/src/components/listings/ListingGrid.tsx
@@ -1,0 +1,45 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { NeoCard, NeoCardHeader, NeoCardTitle } from '@/components/ui/neo-card';
+import type { ListingSummaryDTO } from '@/types/dto';
+
+interface ListingGridProps {
+  listings: ListingSummaryDTO[];
+}
+
+export function ListingGrid({ listings }: ListingGridProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      {listings.map((listing) => (
+        <Link key={listing.id} href={`/listings/${listing.slug}`} className="block">
+          <NeoCard
+            variant="elevated"
+            className="group hover:shadow-[16px_16px_0px_0px] transition-all duration-300 cursor-pointer"
+          >
+            <div className="relative h-48 mb-4 overflow-hidden rounded-lg">
+              {listing.imageUrl && (
+                <Image
+                  src={listing.imageUrl}
+                  alt={`${listing.name}, ${listing.city?.name ?? ''}`}
+                  fill
+                  sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                  className="object-cover group-hover:scale-105 transition-transform duration-300"
+                />
+              )}
+            </div>
+            <NeoCardHeader>
+              <NeoCardTitle className="group-hover:text-neo-primary transition-colors duration-200">
+                {listing.name}
+              </NeoCardTitle>
+              {listing.city?.name && (
+                <p className="body-sm text-neo-text-secondary mt-1">
+                  {listing.city.name}
+                </p>
+              )}
+            </NeoCardHeader>
+          </NeoCard>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app-next-directory/src/components/sections/CityCarousel.tsx
+++ b/app-next-directory/src/components/sections/CityCarousel.tsx
@@ -53,8 +53,8 @@ export function CityCarousel() {
   }, [cities.length]);
 
   const router = useRouter();
-  const handleExploreCity = (cityId: string) => {
-    router.push(`/cities/${cityId}`);
+  const handleExploreCity = (citySlug: string) => {
+    router.push(`/city/${citySlug}`);
   };
 
   if (loading) {
@@ -202,7 +202,7 @@ export function CityCarousel() {
                     variant="primary"
                     size="sm"
                     aria-label={`Explore ${city.name}`}
-                    onClick={() => handleExploreCity(city.id)}
+                    onClick={() => handleExploreCity(city.slug)}
                   >
                     Explore City
                   </NeoButton>

--- a/app-next-directory/src/types/city.ts
+++ b/app-next-directory/src/types/city.ts
@@ -1,0 +1,1 @@
+export type { CityDTO } from './dto';


### PR DESCRIPTION
## Summary
- add CityDetailView and ListingGrid components
- wire up mock city listings and detail page
- route CityCarousel cards to their city page

## Testing
- `pnpm test` *(fails: No projects matched the filters)*
- `pnpm typecheck` *(fails: Cannot find name 'SanityReference')*

------
https://chatgpt.com/codex/tasks/task_e_68ada403c3dc83239fc3e0192ea84f14