### PR TITLE
Add login & signup pages with social auth

### DIFF
--- a/app-next-directory/app/auth/login/page.tsx
+++ b/app-next-directory/app/auth/login/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { NeoInput } from '@/components/ui/neo-input';
+import { NeoButton } from '@/components/ui/neo-button';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    });
+    if (res?.error) {
+      setError(res.error);
+    } else {
+      window.location.href = '/';
+    }
+  };
+
+  const socialProviders = [
+    { id: 'facebook', name: 'Facebook' },
+    { id: 'twitter', name: 'X' },
+    { id: 'microsoft', name: 'Hotmail' },
+    { id: 'google', name: 'Gmail' },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
+        <NeoInput
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <NeoInput
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <NeoButton type="submit" className="w-full">
+          Login
+        </NeoButton>
+      </form>
+      <div className="mt-6 space-y-2 w-full max-w-md">
+        {socialProviders.map((p) => (
+          <NeoButton
+            key={p.id}
+            variant="outline"
+            className="w-full"
+            onClick={() => signIn(p.id)}
+          >
+            Sign in with {p.name}
+          </NeoButton>
+        ))}
+      </div>
+      <p className="mt-4 text-sm">
+        New user?{' '}
+        <Link href="/auth/signup" className="text-blue-600">
+          Create an account
+        </Link>
+      </p>
+    </div>
+  );
+}
+

--- a/app-next-directory/app/auth/signup/page.tsx
+++ b/app-next-directory/app/auth/signup/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { signIn } from 'next-auth/react';
+import { NeoInput } from '@/components/ui/neo-input';
+import { NeoButton } from '@/components/ui/neo-button';
+
+export default function SignupPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      setError(data?.error?.message || 'Failed to sign up');
+      return;
+    }
+    await signIn('credentials', { email, password, callbackUrl: '/' });
+  };
+
+  const socialProviders = [
+    { id: 'facebook', name: 'Facebook' },
+    { id: 'twitter', name: 'X' },
+    { id: 'microsoft', name: 'Hotmail' },
+    { id: 'google', name: 'Gmail' },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
+        <NeoInput
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <NeoInput
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <NeoInput
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <NeoButton type="submit" className="w-full">
+          Sign Up
+        </NeoButton>
+      </form>
+      <div className="mt-6 space-y-2 w-full max-w-md">
+        {socialProviders.map((p) => (
+          <NeoButton
+            key={p.id}
+            variant="outline"
+            className="w-full"
+            onClick={() => signIn(p.id)}
+          >
+            Continue with {p.name}
+          </NeoButton>
+        ))}
+      </div>
+      <p className="mt-4 text-sm">
+        Already have an account?{' '}
+        <Link href="/auth/login" className="text-blue-600">
+          Log in
+        </Link>
+      </p>
+    </div>
+  );
+}
+

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -2,11 +2,15 @@
 
 import React from 'react'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
 import { NeoButton } from '@/components/ui/neo-button'
 import { NeoBadge } from '@/components/ui/neo-badge'
 import { User, Menu } from 'lucide-react'
 
 export function Header() {
+  const { data: session } = useSession()
+  const authLink = session ? '/auth/login' : '/auth/signup'
+
   return (
     <header className="w-full bg-background border-b-4 border-neo-border">
       <div className="container mx-auto px-4 py-4">
@@ -51,9 +55,12 @@ export function Header() {
             <NeoButton asChild variant="outline" size="md">
               <Link href="/listings/new">Add Your Listing</Link>
             </NeoButton>
-            <div className="w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center">
+            <Link
+              href={authLink}
+              className="w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center"
+            >
               <User size={20} className="text-neo-text-primary" />
-            </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/app-next-directory/src/lib/auth.ts
+++ b/app-next-directory/src/lib/auth.ts
@@ -1,8 +1,71 @@
 
 import NextAuth, { type NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import Google from "next-auth/providers/google";
+import Facebook from "next-auth/providers/facebook";
+import Twitter from "next-auth/providers/twitter";
+import Microsoft from "next-auth/providers/microsoft";
+import { MongoDBAdapter } from "@auth/mongodb-adapter";
+import clientPromise from "@/lib/mongodb";
+import { authenticateUser } from "@/lib/auth/serverAuth";
 
 export const authOptions: NextAuthConfig = {
-  providers: [],
+  adapter: MongoDBAdapter(clientPromise),
+  session: { strategy: "jwt" },
+  providers: [
+    Credentials({
+      name: "credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) return null;
+        const user = await authenticateUser(credentials.email, credentials.password);
+        if (!user) return null;
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role,
+          image: user.image,
+        } as any;
+      },
+    }),
+    Facebook({
+      clientId: process.env.FACEBOOK_CLIENT_ID!,
+      clientSecret: process.env.FACEBOOK_CLIENT_SECRET!,
+    }),
+    Twitter({
+      clientId: process.env.X_CLIENT_ID!,
+      clientSecret: process.env.X_CLIENT_SECRET!,
+    }),
+    Microsoft({
+      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+      tenantId: "common",
+    }),
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = (user as any).id ?? token.id;
+        token.role = (user as any).role ?? token.role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token && session.user) {
+        (session.user as any).id = token.id as string;
+        (session.user as any).role = token.role as string | undefined;
+      }
+      return session;
+    },
+  },
 };
 
 export const { handlers: { GET, POST }, auth } = NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- add NextAuth configuration for credentials plus Facebook, X, Microsoft, and Google providers
- create dedicated login and signup pages with social login buttons
- update header icon to dynamically link to login or signup depending on session

## Testing
- `pnpm test` *(fails: No projects matched the filters)*
- `pnpm lint` *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68ada52dc2108323aad204a24113437c