### PR TITLE
Revise header navigation and add layout to auth and blog pages

### DIFF
--- a/app-next-directory/app/auth/login/page.tsx
+++ b/app-next-directory/app/auth/login/page.tsx
@@ -2,50 +2,49 @@ import Link from 'next/link';
 import { NeoCard, NeoCardContent, NeoCardHeader, NeoCardTitle } from '@/components/ui/neo-card';
 import SocialAuthRow from '@/components/auth/SocialAuthRow';
 import LoginForm from './LoginForm';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
 
 export default function LoginPage() {
   return (
-    <div className="relative min-h-screen flex items-center justify-center px-4">
-      {/* Background accents */}
-      <div aria-hidden="true" className="absolute inset-0 -z-10 bg-gradient-to-br from-neo-secondary/10 via-white to-neo-primary/10" />
-      <div aria-hidden="true" className="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-neo-primary/10 blur-3xl" />
-      <div aria-hidden="true" className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl" />
-      <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
-        {/* Left panel */}
-        <div className="hidden md:flex flex-col justify-center p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
-          <h2 className="heading-lg mb-3" id="welcome-heading">Welcome back</h2>
-          <p className="body-md">Log in to manage your listings, save favorites, and discover eco-friendly spots for digital nomads.</p>
-          <div className="mt-8" aria-labelledby="social-signin-heading-left">
-            <h3 id="social-signin-heading-left" className="sr-only">Social sign-in options</h3>
-            <SocialAuthRow />
-          </div>        </div>
-
-        {/* Auth card */}
-        <NeoCard className="p-8 md:p-10">
-          <NeoCardHeader>
-            <NeoCardTitle>Log in</NeoCardTitle>
-          </NeoCardHeader>
-          <NeoCardContent>
-           <NeoCardContent>
-             <LoginForm />
-             <div className="mt-6 md:hidden" aria-labelledby="social-signin-heading-mobile">
-               <h3 id="social-signin-heading-mobile" className="sr-only">Social sign-in options</h3>
-               <SocialAuthRow />
-             </div>
-
-             <p className="mt-6 text-sm text-center">
-            <div className="mt-6 md:hidden" aria-labelledby="social-signin-heading-mobile">
-              <h3 id="social-signin-heading-mobile" className="sr-only">Social sign-in options</h3>
+    <>
+      <Header />
+      <div className="relative min-h-screen flex items-center justify-center px-4">
+        {/* Background accents */}
+        <div aria-hidden="true" className="absolute inset-0 -z-10 bg-gradient-to-br from-neo-secondary/10 via-white to-neo-primary/10" />
+        <div aria-hidden="true" className="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-neo-primary/10 blur-3xl" />
+        <div aria-hidden="true" className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl" />
+        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+          {/* Left panel */}
+          <div className="hidden md:flex flex-col justify-center p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
+            <h2 className="heading-lg mb-3" id="welcome-heading">Welcome back</h2>
+            <p className="body-md">Log in to manage your listings, save favorites, and discover eco-friendly spots for digital nomads.</p>
+            <div className="mt-8" aria-labelledby="social-signin-heading-left">
+              <h3 id="social-signin-heading-left" className="sr-only">Social sign-in options</h3>
               <SocialAuthRow />
             </div>
-
-            <p className="mt-6 text-sm text-center">
-              New user?{' '}
-              <Link href="/auth/signup" className="text-neo-primary hover:underline">Create an account</Link>
-            </p>
-          </NeoCardContent>
-        </NeoCard>
+          </div>
+          {/* Auth card */}
+          <NeoCard className="p-8 md:p-10">
+            <NeoCardHeader>
+              <NeoCardTitle>Log in</NeoCardTitle>
+            </NeoCardHeader>
+            <NeoCardContent>
+              <LoginForm />
+              <div className="mt-6 md:hidden" aria-labelledby="social-signin-heading-mobile">
+                <h3 id="social-signin-heading-mobile" className="sr-only">Social sign-in options</h3>
+                <SocialAuthRow />
+              </div>
+              <p className="mt-6 text-sm text-center">
+                New user?{' '}
+                <Link href="/auth/signup" className="text-neo-primary hover:underline">Create an account</Link>
+              </p>
+            </NeoCardContent>
+          </NeoCard>
+        </div>
       </div>
-    </div>
+      <Footer />
+    </>
   );
 }
+

--- a/app-next-directory/app/auth/signup/page.tsx
+++ b/app-next-directory/app/auth/signup/page.tsx
@@ -7,6 +7,8 @@ import { NeoInput } from '@/components/ui/neo-input';
 import { NeoButton } from '@/components/ui/neo-button';
 import { NeoCard, NeoCardContent, NeoCardHeader, NeoCardTitle } from '@/components/ui/neo-card';
 import SocialAuthRow from '@/components/auth/SocialAuthRow';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
 
 export default function SignupPage() {
   const [name, setName] = useState('');
@@ -31,6 +33,8 @@ export default function SignupPage() {
   };
 
   return (
+    <>
+    <Header />
     <div className="relative min-h-screen flex items-center justify-center px-4">
       {/* Background accents */}
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-neo-secondary/10 via-white to-neo-primary/10" />
@@ -112,6 +116,8 @@ export default function SignupPage() {
         </NeoCard>
       </div>
     </div>
+    <Footer />
+    </>
   );
 }
 

--- a/app-next-directory/src/app/blog/page.tsx
+++ b/app-next-directory/src/app/blog/page.tsx
@@ -2,6 +2,8 @@
 import Link from 'next/link';
 import { getBaseUrl } from '@/lib/absolute-url';
 import type { Metadata } from 'next'
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
 
 type Post = {
   _id: string;
@@ -83,6 +85,8 @@ export default async function BlogPage({ searchParams }: Readonly<{ searchParams
   ).slice(0, 20);
 
   return (
+    <>
+    <Header />
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-5xl font-extrabold text-center mb-6 text-gray-900">The Nomad's Chronicle</h1>
 
@@ -163,5 +167,7 @@ export default async function BlogPage({ searchParams }: Readonly<{ searchParams
         )}
       </div>
     </div>
+    <Footer />
+    </>
   );
 }

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -2,8 +2,6 @@
 
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
-import { NeoButton } from '@/components/ui/neo-button'
-import { NeoBadge } from '@/components/ui/neo-badge'
 import { User, Menu } from 'lucide-react'
 
 export function Header() {
@@ -15,12 +13,6 @@ export function Header() {
     <header className="w-full bg-background border-b-4 border-neo-border">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
-          {/* Product Hunt Badge */}
-          <div className="flex items-center space-x-4">
-            <NeoBadge variant="secondary" className="hidden md:flex">
-              <span className="text-xs font-bold">🏆 #1 Product of the Day</span>
-            </NeoBadge>
-          </div>
 
           {/* Navigation */}
           {/* Mobile menu trigger (scaffold) */}
@@ -33,28 +25,22 @@ export function Header() {
             <span className="sr-only">Open menu</span>
           </button>
           <nav className="hidden md:flex items-center space-x-8">
-            <Link href="/about" className="body-md hover:text-neo-primary font-semibold transition-colors">
-              About us
+            <Link href="/" className="body-md hover:text-neo-primary font-semibold transition-colors">
+              Home
             </Link>
-            <Link href="/contact-us" className="body-md hover:text-neo-primary font-semibold transition-colors">
-              Contact us
+            <Link href="/search" className="body-md hover:text-neo-primary font-semibold transition-colors">
+              Find
             </Link>
-            <div className="w-8 h-8 bg-neo-primary rounded-full flex items-center justify-center">
-              <div className="w-4 h-4 bg-white rounded-full"></div>
-            </div>
             <Link href="/blog" className="body-md hover:text-neo-primary font-semibold transition-colors">
               Blog
             </Link>
-            <Link href="/search" className="body-md hover:text-neo-primary font-semibold transition-colors">
-              Search
+            <Link href="/contact-us" className="body-md hover:text-neo-primary font-semibold transition-colors">
+              Contact
             </Link>
           </nav>
 
           {/* CTA Button */}
           <div className="flex items-center space-x-4">
-            <NeoButton asChild variant="outline" size="md">
-              <Link href="/listings/new">Add Your Listing</Link>
-            </NeoButton>
             {status !== 'loading' && (
               <Link
                 href={authLink}


### PR DESCRIPTION
## Summary
- Simplify header by removing Product Hunt badge and listing CTA
- Reorder navigation links and rename labels
- Show header and footer on blog, login, and signup pages

## Testing
- `npm test` *(fails: Missing script "test" in workspace)*
- `npm run lint` *(fails: Missing script "lint" in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f576dac83239dbc0907c2324211