### PR TITLE
Fix authentication session context and enhance login feedback

### DIFF
--- a/app-next-directory/src/app/auth/login/page.tsx
+++ b/app-next-directory/src/app/auth/login/page.tsx
@@ -1,9 +1,41 @@
 "use client";
 
 import React from 'react';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
+import { useSearchParams } from 'next/navigation';
+import { CheckCircle2 } from 'lucide-react';
 
 export default function LoginPage() {
+  const { data: session, status } = useSession();
+  const searchParams = useSearchParams();
+  const rawCallbackUrl = searchParams?.get('callbackUrl') ?? undefined;
+
+  const callbackUrl = React.useMemo(() => {
+    if (!rawCallbackUrl) return undefined;
+    if (rawCallbackUrl.startsWith('/')) return rawCallbackUrl;
+
+    if (typeof window !== 'undefined') {
+      try {
+        const url = new URL(rawCallbackUrl, window.location.origin);
+        if (url.origin === window.location.origin) {
+          return `${url.pathname}${url.search}${url.hash}`;
+        }
+      } catch {
+        // Ignore invalid callback URLs and fall back to defaults
+      }
+    }
+
+    return undefined;
+  }, [rawCallbackUrl]);
+
+  const isAuthenticated = status === 'authenticated';
+  const displayName = session?.user?.name ?? session?.user?.email ?? 'your account';
+
+  const handleProviderSignIn = (provider: string) => {
+    const options = callbackUrl ? { callbackUrl } : undefined;
+    void signIn(provider, options);
+  };
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-6">
       <div className="w-full max-w-md border-4 border-black rounded-xl bg-white p-6 shadow-[12px_12px_0_0_rgba(0,0,0,1)]">
@@ -12,11 +44,51 @@ export default function LoginPage() {
           Choose a provider to continue
         </p>
 
+        {isAuthenticated && (
+          <div className="mb-6 flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-800">
+            <CheckCircle2 className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+            <div>
+              <p className="font-semibold">Signed in successfully</p>
+              <p className="text-sm text-emerald-700">
+                You're signed in as {displayName}. {callbackUrl ? 'You can head back to your previous page.' : 'Feel free to continue exploring listings.'}
+              </p>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-3">
-          <button className="w-full btn btn-primary" onClick={() => signIn('google')}>Continue with Google</button>
-          <button className="w-full btn btn-primary" onClick={() => signIn('facebook')}>Continue with Facebook</button>
-          <button className="w-full btn btn-primary" onClick={() => signIn('twitter')}>Continue with X</button>
-          <button className="w-full btn btn-primary" onClick={() => signIn('microsoft-entra-id')}>Continue with Microsoft</button>
+          <button
+            type="button"
+            className="w-full btn btn-primary"
+            onClick={() => handleProviderSignIn('google')}
+            disabled={isAuthenticated}
+          >
+            Continue with Google
+          </button>
+          <button
+            type="button"
+            className="w-full btn btn-primary"
+            onClick={() => handleProviderSignIn('facebook')}
+            disabled={isAuthenticated}
+          >
+            Continue with Facebook
+          </button>
+          <button
+            type="button"
+            className="w-full btn btn-primary"
+            onClick={() => handleProviderSignIn('twitter')}
+            disabled={isAuthenticated}
+          >
+            Continue with X
+          </button>
+          <button
+            type="button"
+            className="w-full btn btn-primary"
+            onClick={() => handleProviderSignIn('microsoft-entra-id')}
+            disabled={isAuthenticated}
+          >
+            Continue with Microsoft
+          </button>
         </div>
 
         <p className="text-xs text-neo-text-secondary mt-6">

--- a/app-next-directory/src/app/layout.tsx
+++ b/app-next-directory/src/app/layout.tsx
@@ -4,6 +4,8 @@ import type { Metadata } from 'next'
 import { Inter, Space_Grotesk } from 'next/font/google'
 import dynamic from 'next/dynamic'
 
+import Providers from '@/components/Providers'
+
 const inter = Inter({ subsets: ['latin'] })
 const spaceGrotesk = Space_Grotesk({ subsets: ['latin'] })
 
@@ -22,8 +24,10 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         {/* Start MSW worker only during E2E runs (no-op otherwise) */}
-        <MswInit />
-        {children}
+        <Providers>
+          <MswInit />
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/app-next-directory/src/components/Providers.tsx
+++ b/app-next-directory/src/components/Providers.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import type { ReactNode } from "react";
+import { AuthProvider } from "@/lib/auth/clientAuth";
+
+interface ProvidersProps {
+  children: ReactNode;
+}
+
+export default function Providers({ children }: ProvidersProps) {
+  return (
+    <SessionProvider>
+      <AuthProvider>{children}</AuthProvider>
+    </SessionProvider>
+  );
+}

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -7,8 +7,10 @@ import Image from 'next/image'
 
 export function Header() {
   const { data: session, status } = useSession()
-
-  const authLink = session ? '/auth/login' : '/auth/signup'
+  const isAuthenticated = status === 'authenticated'
+  const displayName = session?.user?.name ?? session?.user?.email ?? 'your account'
+  const shortName = session?.user?.name?.split(' ')[0] ?? session?.user?.name ?? ''
+  const accountLabel = isAuthenticated ? `Signed in as ${displayName}` : 'Sign in'
 
   return (
     <header className="w-full bg-background border-b-4 border-neo-border">
@@ -56,15 +58,37 @@ export function Header() {
 
           {/* Right: CTA/User */}
           <div className="flex items-center space-x-4">
+            {isAuthenticated && (
+              <span className="hidden md:inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-sm font-semibold text-emerald-700">
+                <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+                {shortName ? `Welcome, ${shortName}!` : 'Signed in'}
+              </span>
+            )}
             {status !== 'loading' && (
-              <Link
-                href={authLink}
-                aria-label={status === 'authenticated' ? 'Account' : 'Sign in'}
-                className="w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-primary"
-              >
-                <span className="sr-only">{status === 'authenticated' ? 'Account' : 'Sign in'}</span>
-                <User size={20} className="text-neo-text-primary" aria-hidden="true" focusable="false" />
-              </Link>
+              isAuthenticated ? (
+                <div
+                  className="relative w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center opacity-60 cursor-not-allowed"
+                  aria-disabled="true"
+                  role="status"
+                  aria-label={accountLabel}
+                  title={accountLabel}
+                >
+                  <span className="sr-only">{accountLabel}</span>
+                  <User size={20} className="text-neo-text-secondary" aria-hidden="true" focusable="false" />
+                  <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-[10px] font-bold text-white" aria-hidden="true">
+                    ✓
+                  </span>
+                </div>
+              ) : (
+                <Link
+                  href="/auth/login"
+                  aria-label="Sign in"
+                  className="w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-primary"
+                >
+                  <span className="sr-only">Sign in</span>
+                  <User size={20} className="text-neo-text-primary" aria-hidden="true" focusable="false" />
+                </Link>
+              )
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap the app shell with a reusable Providers component that mounts NextAuth's SessionProvider and the existing AuthProvider
- improve the login page to preserve callback URLs, surface a success banner, and disable social buttons once authenticated
- update the header icon to reflect signed-in state with a badge, welcome chip, and disabled account control

## Testing
- pnpm --filter app-next-directory lint *(fails: existing lint warnings throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d58899d88323ac57f20bae6a2be9