### PR TITLE
Add user profile experience with favorites and owner reviews

### DIFF
--- a/app-next-directory/app/api/user/reviews/route.ts
+++ b/app-next-directory/app/api/user/reviews/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { auth } from '@/lib/auth';
+import { getCollection } from '@/utils/db-helpers';
+
+type SessionUser = {
+  id?: string | null;
+  role?: string | null;
+  name?: string | null;
+  email?: string | null;
+};
+
+type ListingDoc = {
+  slug?: unknown;
+  name?: unknown;
+  ownerId?: unknown;
+  status?: unknown;
+};
+
+type ReviewDoc = {
+  _id?: unknown;
+  listingSlug?: unknown;
+  rating?: unknown;
+  comment?: unknown;
+  createdAt?: unknown;
+  userName?: unknown;
+  userImage?: unknown;
+  user?: {
+    name?: unknown;
+    image?: unknown;
+  } | null;
+};
+
+type NormalisedListing = {
+  slug: string;
+  name: string;
+};
+
+type NormalisedReview = {
+  id: string;
+  rating: number;
+  comment: string;
+  createdAt: string;
+  reviewerName: string;
+  reviewerImage?: string;
+};
+
+function normaliseSlug(rawSlug: unknown): string | null {
+  if (typeof rawSlug === 'string' && rawSlug.trim().length > 0) {
+    return rawSlug.trim();
+  }
+
+  if (
+    rawSlug &&
+    typeof rawSlug === 'object' &&
+    'current' in rawSlug &&
+    typeof (rawSlug as { current?: unknown }).current === 'string'
+  ) {
+    const slug = (rawSlug as { current?: string }).current ?? '';
+    return slug.trim().length > 0 ? slug.trim() : null;
+  }
+
+  return null;
+}
+
+function normaliseListing(doc: ListingDoc): NormalisedListing | null {
+  const slug = normaliseSlug(doc.slug);
+  if (!slug) {
+    return null;
+  }
+
+  const name = typeof doc.name === 'string' && doc.name.trim().length > 0 ? doc.name.trim() : 'Untitled listing';
+
+  return { slug, name };
+}
+
+function normaliseReview(doc: ReviewDoc): NormalisedReview | null {
+  const ratingNumber = Number(doc.rating);
+  if (!Number.isFinite(ratingNumber) || ratingNumber <= 0) {
+    return null;
+  }
+
+  const comment = typeof doc.comment === 'string' ? doc.comment : '';
+  const createdAt = doc.createdAt instanceof Date
+    ? doc.createdAt.toISOString()
+    : typeof doc.createdAt === 'string' && doc.createdAt.trim().length > 0
+      ? new Date(doc.createdAt).toISOString()
+      : new Date().toISOString();
+
+  let reviewerName: string | undefined;
+  if (typeof doc.userName === 'string' && doc.userName.trim().length > 0) {
+    reviewerName = doc.userName.trim();
+  } else if (doc.user && typeof doc.user.name === 'string' && doc.user.name.trim().length > 0) {
+    reviewerName = doc.user.name.trim();
+  }
+  const reviewerImage =
+    typeof doc.userImage === 'string' && doc.userImage.trim().length > 0
+      ? doc.userImage.trim()
+      : doc.user && typeof doc.user.image === 'string' && doc.user.image.trim().length > 0
+        ? doc.user.image.trim()
+        : undefined;
+
+  const id = typeof doc._id === 'string'
+    ? doc._id
+    : doc._id && typeof doc._id === 'object' && 'toString' in doc._id
+      ? String((doc._id as { toString: () => string }).toString())
+      : randomUUID();
+
+  return {
+    id,
+    rating: ratingNumber,
+    comment,
+    createdAt,
+    reviewerName: reviewerName ?? 'Anonymous nomad',
+    reviewerImage,
+  };
+}
+
+function isDeletedStatus(status: unknown): boolean {
+  if (typeof status !== 'string') return false;
+  const normalised = status.toLowerCase();
+  return normalised === 'deleted' || normalised === 'archived' || normalised === 'removed';
+}
+
+export async function GET() {
+  const session = await auth();
+  const user = session?.user as SessionUser | undefined;
+  const userId = user?.id ?? null;
+  const role = user?.role ?? null;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  if (role !== 'venueOwner') {
+    return NextResponse.json({ listings: [] }, { status: 200 });
+  }
+
+  try {
+    const listingsCollection = await getCollection('listings');
+    const rawListings = await listingsCollection
+      .find({ ownerId: userId })
+      .project({ slug: 1, name: 1, status: 1 })
+      .toArray();
+
+    const listings: NormalisedListing[] = [];
+    for (const doc of rawListings as ListingDoc[]) {
+      if (isDeletedStatus(doc.status)) {
+        continue;
+      }
+      const listing = normaliseListing(doc);
+      if (listing) {
+        listings.push(listing);
+      }
+    }
+
+    if (listings.length === 0) {
+      return NextResponse.json({ listings: [] });
+    }
+
+    const reviewsCollection = await getCollection('reviews');
+    const results: Array<{ slug: string; name: string; reviews: NormalisedReview[] }> = [];
+
+    for (const listing of listings) {
+      const cursor = reviewsCollection
+        .find({ listingSlug: listing.slug, status: 'approved' })
+        .sort({ createdAt: -1 })
+        .limit(50);
+
+      const rawReviews = await cursor.toArray();
+      const reviews: NormalisedReview[] = [];
+      for (const review of rawReviews as ReviewDoc[]) {
+        const normalised = normaliseReview(review);
+        if (normalised) {
+          reviews.push(normalised);
+        }
+      }
+
+      results.push({ slug: listing.slug, name: listing.name, reviews });
+    }
+
+    return NextResponse.json({ listings: results });
+  } catch (error) {
+    console.error('[api/user/reviews] failed to load owner reviews', error);
+    return NextResponse.json({ error: 'Failed to load reviews' }, { status: 500 });
+  }
+}

--- a/app-next-directory/app/profile/page.tsx
+++ b/app-next-directory/app/profile/page.tsx
@@ -1,0 +1,511 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useSession } from 'next-auth/react';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+import {
+  NeoCard,
+  NeoCardContent,
+  NeoCardDescription,
+  NeoCardHeader,
+  NeoCardTitle,
+} from '@/components/ui/neo-card';
+import { NeoBadge } from '@/components/ui/neo-badge';
+import { NeoButton } from '@/components/ui/neo-button';
+import { Heart, Loader2, MapPin, MessageSquare, Star } from 'lucide-react';
+
+interface FavoriteListing {
+  id: string;
+  name: string;
+  slug: string;
+  city?: string;
+  imageUrl?: string;
+  createdAt?: string;
+}
+
+interface OwnerReviewItem {
+  id: string;
+  rating: number;
+  comment: string;
+  createdAt: string;
+  reviewerName: string;
+  reviewerImage?: string;
+}
+
+interface OwnerListingReviews {
+  slug: string;
+  name: string;
+  reviews: OwnerReviewItem[];
+}
+
+interface FavoritesResponse {
+  favorites?: Array<{
+    _id?: string;
+    listing?: {
+      _id?: string;
+      name?: string;
+      slug?: string;
+      mainImage?: {
+        asset?: {
+          url?: string;
+        } | null;
+      } | null;
+      city?: {
+        name?: string;
+      } | null;
+    } | null;
+    createdAt?: string;
+  }>;
+}
+
+interface OwnerReviewsResponse {
+  listings?: OwnerListingReviews[];
+}
+
+function normaliseFavorite(entry: FavoritesResponse['favorites'][number]): FavoriteListing | null {
+  if (!entry) return null;
+  const listing = entry.listing ?? undefined;
+  const slug = typeof listing?.slug === 'string' ? listing.slug : '';
+  if (!slug) return null;
+  const name = typeof listing?.name === 'string' && listing.name.trim().length > 0
+    ? listing.name.trim()
+    : 'Untitled listing';
+
+  const city = typeof listing?.city?.name === 'string' ? listing.city.name : undefined;
+  const imageUrl =
+    typeof listing?.mainImage?.asset?.url === 'string' && listing.mainImage.asset.url.length > 0
+      ? listing.mainImage.asset.url
+      : undefined;
+
+  return {
+    id: entry._id ?? slug,
+    name,
+    slug,
+    city,
+    imageUrl,
+    createdAt: entry.createdAt,
+  };
+}
+
+function normaliseOwnerReviews(response: OwnerReviewsResponse | null | undefined): OwnerListingReviews[] {
+  if (!response?.listings || !Array.isArray(response.listings)) {
+    return [];
+  }
+
+  return response.listings
+    .filter((listing): listing is OwnerListingReviews => Boolean(listing?.slug))
+    .map((listing) => ({
+      slug: listing.slug,
+      name: listing.name?.trim?.() || 'Untitled listing',
+      reviews: Array.isArray(listing.reviews)
+        ? listing.reviews
+            .filter((review): review is OwnerReviewItem => Boolean(review && typeof review.id === 'string'))
+            .map((review) => ({
+              id: review.id,
+              rating: review.rating,
+              comment: review.comment,
+              createdAt: review.createdAt,
+              reviewerName: review.reviewerName,
+              reviewerImage: review.reviewerImage,
+            }))
+        : [],
+    }));
+}
+
+function formatDate(value?: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+}
+
+export default function ProfilePage() {
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+  const displayName = session?.user?.name ?? session?.user?.email ?? 'Your account';
+  const email = session?.user?.email ?? undefined;
+  const role = session?.user?.role ?? 'user';
+
+  const [favorites, setFavorites] = useState<FavoriteListing[]>([]);
+  const [favoritesLoading, setFavoritesLoading] = useState(false);
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
+
+  const [ownerListings, setOwnerListings] = useState<OwnerListingReviews[]>([]);
+  const [ownerLoading, setOwnerLoading] = useState(false);
+  const [ownerError, setOwnerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const controller = new AbortController();
+    const loadFavorites = async () => {
+      setFavoritesLoading(true);
+      setFavoritesError(null);
+      try {
+        const res = await fetch('/api/user/favorites', { signal: controller.signal });
+        if (!res.ok) {
+          throw new Error('Unable to load favorites');
+        }
+        const data = (await res.json()) as FavoritesResponse;
+        const parsed = (data.favorites ?? [])
+          .map(normaliseFavorite)
+          .filter((favorite): favorite is FavoriteListing => Boolean(favorite));
+        setFavorites(parsed);
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setFavoritesError('We could not load your favorites right now. Please try again later.');
+        }
+      } finally {
+        setFavoritesLoading(false);
+      }
+    };
+
+    loadFavorites();
+    return () => {
+      controller.abort();
+    };
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated || role !== 'venueOwner') return;
+    const controller = new AbortController();
+    const loadOwnerReviews = async () => {
+      setOwnerLoading(true);
+      setOwnerError(null);
+      try {
+        const res = await fetch('/api/user/reviews', { signal: controller.signal });
+        if (!res.ok) {
+          if (res.status === 404 || res.status === 204) {
+            setOwnerListings([]);
+            return;
+          }
+          const payload = await res.json().catch(() => ({}));
+          const errorMessage = typeof payload?.error === 'string' ? payload.error : 'Unable to load reviews';
+          throw new Error(errorMessage);
+        }
+        const data = (await res.json()) as OwnerReviewsResponse;
+        setOwnerListings(normaliseOwnerReviews(data));
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setOwnerError('We could not load reviews for your listings. Please try again later.');
+        }
+      } finally {
+        setOwnerLoading(false);
+      }
+    };
+
+    loadOwnerReviews();
+    return () => {
+      controller.abort();
+    };
+  }, [isAuthenticated, role]);
+
+  const initials = useMemo(() => {
+    const source = session?.user?.name ?? session?.user?.email ?? '';
+    if (!source) return 'U';
+    return source
+      .split(' ')
+      .map((part) => part.trim().charAt(0).toUpperCase())
+      .join('')
+      .slice(0, 2);
+  }, [session?.user?.name, session?.user?.email]);
+
+  const favoriteDateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }),
+    []
+  );
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="container mx-auto px-4 py-12 space-y-12" data-testid="user-profile-page">
+        {status === 'loading' ? (
+          <section className="flex flex-col items-center justify-center py-24">
+            <Loader2 className="h-8 w-8 animate-spin text-neo-primary" aria-hidden="true" />
+            <p className="mt-4 text-sm text-neo-text-secondary">Loading your profile…</p>
+          </section>
+        ) : !isAuthenticated ? (
+          <section className="max-w-3xl mx-auto">
+            <NeoCard variant="elevated" className="bg-white/90">
+              <NeoCardHeader>
+                <NeoCardTitle>Sign in to view your profile</NeoCardTitle>
+                <NeoCardDescription>
+                  Access your saved favorites and keep track of your sustainable venues.
+                </NeoCardDescription>
+              </NeoCardHeader>
+              <NeoCardContent className="pt-0">
+                <NeoButton asChild variant="secondary">
+                  <Link href="/auth?mode=signin">Go to sign in</Link>
+                </NeoButton>
+              </NeoCardContent>
+            </NeoCard>
+          </section>
+        ) : (
+          <>
+            <section aria-labelledby="profile-overview">
+              <NeoCard variant="elevated" className="bg-white/95">
+                <NeoCardContent className="flex flex-col gap-6 md:flex-row md:items-center">
+                  <div className="relative h-20 w-20 overflow-hidden rounded-full border-4 border-neo-border bg-neo-surface">
+                    {session?.user?.image ? (
+                      <Image
+                        src={session.user.image}
+                        alt={`${displayName} avatar`}
+                        width={80}
+                        height={80}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-neo-secondary text-lg font-semibold text-neo-text-primary">
+                        {initials}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-2">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <h1 id="profile-overview" className="heading-lg text-neo-text-primary">
+                        {displayName}
+                      </h1>
+                      <NeoBadge variant="secondary" size="sm" aria-label={`Account role: ${role}`}>
+                        {role === 'venueOwner' ? 'Venue Owner' : role.charAt(0).toUpperCase() + role.slice(1)}
+                      </NeoBadge>
+                    </div>
+                    {email && (
+                      <p className="text-sm text-neo-text-secondary">
+                        <span className="font-semibold">Email:</span> {email}
+                      </p>
+                    )}
+                    <p className="text-sm text-neo-text-secondary">
+                      Keep exploring sustainable venues and manage the places you love.
+                    </p>
+                  </div>
+                </NeoCardContent>
+              </NeoCard>
+            </section>
+
+            <section id="favorites" aria-labelledby="favorites-heading" data-testid="profile-favorites" className="space-y-4">
+              <div className="flex items-center justify-between gap-4 flex-wrap">
+                <div>
+                  <h2 id="favorites-heading" className="heading-md text-neo-text-primary flex items-center gap-2">
+                    <Heart className="h-5 w-5 text-neo-primary" aria-hidden="true" />
+                    Favorite listings
+                  </h2>
+                  <p className="text-sm text-neo-text-secondary">
+                    A quick view of the sustainable venues you&apos;ve saved.
+                  </p>
+                </div>
+                <NeoButton asChild variant="secondary">
+                  <Link href="/search">Discover more venues</Link>
+                </NeoButton>
+              </div>
+
+              {favoritesLoading ? (
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" role="status" aria-live="polite">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <div
+                      key={index}
+                      className="h-48 animate-pulse rounded-xl border-2 border-dashed border-neo-border/60 bg-white/60"
+                    />
+                  ))}
+                </div>
+              ) : favoritesError ? (
+                <NeoCard variant="flat" className="bg-rose-50 border-rose-200">
+                  <NeoCardHeader className="pb-2">
+                    <NeoCardTitle className="text-base text-rose-700">We couldn&apos;t load your favorites</NeoCardTitle>
+                  </NeoCardHeader>
+                  <NeoCardContent className="pt-0 text-sm text-rose-700">{favoritesError}</NeoCardContent>
+                </NeoCard>
+              ) : favorites.length === 0 ? (
+                <NeoCard variant="flat" className="bg-white/90">
+                  <NeoCardContent className="flex flex-col items-start gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="font-semibold text-neo-text-primary">You haven&apos;t saved any venues yet.</p>
+                      <p className="text-sm text-neo-text-secondary">
+                        Explore eco-friendly spaces and tap the heart icon to save your favorites.
+                      </p>
+                    </div>
+                    <NeoButton asChild variant="accent">
+                      <Link href="/search">Start exploring</Link>
+                    </NeoButton>
+                  </NeoCardContent>
+                </NeoCard>
+              ) : (
+                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                  {favorites.map((favorite) => (
+                    <NeoCard key={favorite.id} variant="flat" className="bg-white/95" data-testid="favorite-item">
+                      <NeoCardContent className="space-y-4">
+                        <div className="relative h-40 w-full overflow-hidden rounded-xl border-2 border-neo-border bg-neo-surface">
+                          {favorite.imageUrl ? (
+                            <Image
+                              src={favorite.imageUrl}
+                              alt={`${favorite.name} preview`}
+                              fill
+                              sizes="(max-width: 768px) 100vw, 33vw"
+                              className="object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-neo-secondary/60 text-neo-text-primary">
+                              <MapPin className="h-8 w-8" aria-hidden="true" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="space-y-2">
+                          <h3 className="text-lg font-semibold text-neo-text-primary">{favorite.name}</h3>
+                          {favorite.city && (
+                            <p className="text-sm text-neo-text-secondary flex items-center gap-1">
+                              <MapPin className="h-4 w-4" aria-hidden="true" />
+                              {favorite.city}
+                            </p>
+                          )}
+                          {favorite.createdAt && (
+                            <p className="text-xs text-neo-text-secondary">
+                              Saved on {favoriteDateFormatter.format(new Date(favorite.createdAt))}
+                            </p>
+                          )}
+                        </div>
+                        <NeoButton asChild variant="secondary" size="sm">
+                          <Link href={`/listings/${favorite.slug}`}>View listing</Link>
+                        </NeoButton>
+                      </NeoCardContent>
+                    </NeoCard>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {role === 'venueOwner' && (
+              <section
+                id="owner-reviews"
+                aria-labelledby="owner-reviews-heading"
+                data-testid="profile-owner-reviews"
+                className="space-y-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <h2 id="owner-reviews-heading" className="heading-md text-neo-text-primary flex items-center gap-2">
+                      <MessageSquare className="h-5 w-5 text-neo-primary" aria-hidden="true" />
+                      Reviews for your venues
+                    </h2>
+                    <p className="text-sm text-neo-text-secondary">
+                      Keep an eye on what guests love about your eco-friendly spaces.
+                    </p>
+                  </div>
+                </div>
+
+                {ownerLoading ? (
+                  <div className="space-y-4" role="status" aria-live="polite">
+                    {Array.from({ length: 2 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className="h-40 animate-pulse rounded-xl border-2 border-dashed border-neo-border/60 bg-white/60"
+                      />
+                    ))}
+                  </div>
+                ) : ownerError ? (
+                  <NeoCard variant="flat" className="bg-rose-50 border-rose-200">
+                    <NeoCardHeader className="pb-2">
+                      <NeoCardTitle className="text-base text-rose-700">{ownerError}</NeoCardTitle>
+                    </NeoCardHeader>
+                  </NeoCard>
+                ) : ownerListings.length === 0 ? (
+                  <NeoCard variant="flat" className="bg-white/90">
+                    <NeoCardContent className="py-6 text-sm text-neo-text-secondary">
+                      You don&apos;t have any published listings with reviews yet. Listings you create will appear here once guests
+                      share their experiences.
+                    </NeoCardContent>
+                  </NeoCard>
+                ) : (
+                  <div className="space-y-6">
+                    {ownerListings.map((listing) => {
+                      const averageRating =
+                        listing.reviews.length > 0
+                          ? listing.reviews.reduce((sum, review) => sum + review.rating, 0) / listing.reviews.length
+                          : null;
+
+                      return (
+                        <NeoCard key={listing.slug} variant="flat" className="bg-white/95">
+                          <NeoCardHeader className="space-y-2">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <div>
+                                <NeoCardTitle className="text-lg text-neo-text-primary">{listing.name}</NeoCardTitle>
+                                <Link
+                                  href={`/listings/${listing.slug}`}
+                                  className="text-sm font-medium text-neo-primary hover:underline"
+                                >
+                                  View public listing
+                                </Link>
+                              </div>
+                              {averageRating ? (
+                                <div className="flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700">
+                                  <Star className="h-4 w-4" aria-hidden="true" />
+                                  {averageRating.toFixed(1)}
+                                  <span className="text-xs font-normal text-emerald-600">
+                                    ({listing.reviews.length} review{listing.reviews.length === 1 ? '' : 's'})
+                                  </span>
+                                </div>
+                              ) : (
+                                <span className="text-xs font-medium text-neo-text-secondary">
+                                  No reviews yet
+                                </span>
+                              )}
+                            </div>
+                          </NeoCardHeader>
+                          <NeoCardContent className="space-y-4">
+                            {listing.reviews.length === 0 ? (
+                              <p className="text-sm text-neo-text-secondary">
+                                No reviews yet. Encourage your guests to share their experience!
+                              </p>
+                            ) : (
+                              <ul className="space-y-4">
+                                {listing.reviews.map((review) => (
+                                  <li key={review.id} className="rounded-xl border border-neo-border/70 bg-white/80 p-4">
+                                    <div className="flex items-center justify-between gap-3">
+                                      <div className="flex items-center gap-3">
+                                        <div className="h-10 w-10 overflow-hidden rounded-full bg-neo-secondary/40">
+                                          {review.reviewerImage ? (
+                                            <Image
+                                              src={review.reviewerImage}
+                                              alt={`${review.reviewerName} avatar`}
+                                              width={40}
+                                              height={40}
+                                              className="h-full w-full object-cover"
+                                            />
+                                          ) : (
+                                            <div className="flex h-full w-full items-center justify-center text-sm font-semibold text-neo-text-primary">
+                                              {review.reviewerName.charAt(0).toUpperCase()}
+                                            </div>
+                                          )}
+                                        </div>
+                                        <div>
+                                          <p className="text-sm font-semibold text-neo-text-primary">{review.reviewerName}</p>
+                                          <p className="text-xs text-neo-text-secondary">{formatDate(review.createdAt)}</p>
+                                        </div>
+                                      </div>
+                                      <div className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-1 text-sm font-semibold text-emerald-700">
+                                        <Star className="h-4 w-4" aria-hidden="true" />
+                                        {review.rating.toFixed(1)}
+                                      </div>
+                                    </div>
+                                    {review.comment && (
+                                      <p className="mt-3 text-sm text-neo-text-secondary">{review.comment}</p>
+                                    )}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </NeoCardContent>
+                        </NeoCard>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            )}
+          </>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link'
 import { signOut, useSession } from 'next-auth/react'
-import { DoorOpen, Menu, User } from 'lucide-react'
+import { DoorOpen, Heart, Menu, User, ChevronDown } from 'lucide-react'
 import Image from 'next/image'
 import { useCallback, useState } from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
 export function Header() {
   const { data: session, status } = useSession()
@@ -13,6 +14,16 @@ export function Header() {
   const shortName = session?.user?.name?.split(' ')[0] ?? session?.user?.name ?? ''
   const accountLabel = isAuthenticated ? `Signed in as ${displayName}` : 'Sign in'
   const [signingOut, setSigningOut] = useState(false)
+  const userImage = typeof session?.user?.image === 'string' ? session.user.image : null
+  const accountInitials = (() => {
+    const source = session?.user?.name ?? session?.user?.email ?? ''
+    if (!source) return 'U'
+    return source
+      .split(' ')
+      .map((part) => part.trim().charAt(0).toUpperCase())
+      .join('')
+      .slice(0, 2)
+  })()
 
   const handleSignOut = useCallback(async () => {
     if (signingOut) return
@@ -85,20 +96,76 @@ export function Header() {
             )}
             {status !== 'loading' && (
               isAuthenticated ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    void handleSignOut()
-                  }}
-                  className="w-10 h-10 bg-neo-surface neo-card rounded-full flex items-center justify-center text-neo-text-secondary transition hover:text-neo-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-primary"
-                  aria-label="Sign out"
-                  title={accountLabel}
-                  disabled={signingOut}
-                  aria-disabled={signingOut}
-                >
-                  <span className="sr-only">Sign out</span>
-                  <DoorOpen size={20} aria-hidden="true" focusable="false" />
-                </button>
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger asChild>
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 rounded-full border-2 border-neo-border bg-neo-surface px-2 py-1 pr-3 text-sm font-semibold text-neo-text-primary transition hover:border-neo-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-primary"
+                      aria-label="Open account menu"
+                      aria-haspopup="menu"
+                    >
+                      <span className="relative inline-flex h-9 w-9 overflow-hidden rounded-full bg-neo-secondary/40">
+                        {userImage ? (
+                          <Image
+                            src={userImage}
+                            alt={`${displayName} avatar`}
+                            width={36}
+                            height={36}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <span className="flex h-full w-full items-center justify-center text-xs uppercase text-neo-text-primary">
+                            {accountInitials}
+                          </span>
+                        )}
+                      </span>
+                      <span className="hidden sm:inline text-xs text-neo-text-secondary">Account</span>
+                      <ChevronDown className="h-4 w-4 text-neo-text-secondary" aria-hidden="true" />
+                    </button>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Content
+                    align="end"
+                    sideOffset={12}
+                    className="z-50 min-w-[220px] rounded-xl border border-neo-border bg-white/95 p-2 shadow-lg backdrop-blur"
+                  >
+                    <DropdownMenu.Label className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-neo-text-secondary">
+                      {accountLabel}
+                    </DropdownMenu.Label>
+                    <DropdownMenu.Separator className="my-2 h-px bg-neo-border/60" />
+                    <DropdownMenu.Item asChild>
+                      <Link
+                        href="/profile"
+                        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neo-text-primary outline-none transition data-[highlighted]:bg-neo-primary/10"
+                      >
+                        <User size={16} aria-hidden="true" />
+                        My profile
+                      </Link>
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item asChild>
+                      <Link
+                        href="/profile#favorites"
+                        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neo-text-primary outline-none transition data-[highlighted]:bg-neo-primary/10"
+                      >
+                        <Heart size={16} aria-hidden="true" />
+                        Favorite listings
+                      </Link>
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator className="my-2 h-px bg-neo-border/60" />
+                    <DropdownMenu.Item
+                      disabled={signingOut}
+                      onSelect={(event) => {
+                        event.preventDefault()
+                        if (!signingOut) {
+                          void handleSignOut()
+                        }
+                      }}
+                      className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-neo-text-primary outline-none transition data-[highlighted]:bg-rose-100 data-[highlighted]:text-rose-700 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60"
+                    >
+                      <DoorOpen size={16} aria-hidden="true" />
+                      {signingOut ? 'Signing out…' : 'Sign out'}
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Root>
               ) : (
 
                 <Link href="/auth" aria-label="Sign in">


### PR DESCRIPTION
## Summary
- add a client-side `/profile` page that surfaces the signed-in user details, saved favorites, and venue-owner review insights
- expose an authenticated `/api/user/reviews` endpoint that aggregates approved reviews for the current owner’s listings
- refresh the header account UI with a dropdown menu linking to the profile and favorites while keeping sign-out accessible

## Testing
- pnpm lint *(fails: repository already contains numerous ESLint warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c7577a688323afb285a063e44e9a