### PR TITLE
Align server auth imports with mocks and skip db connect in tests

### DIFF
--- a/app-next-directory/src/lib/auth/serverAuth.test.ts
+++ b/app-next-directory/src/lib/auth/serverAuth.test.ts
@@ -16,12 +16,12 @@ const mockBcrypt = {
   hash: jest.fn(),
 };
 
-jest.mock('../../models/User', () => ({
+jest.mock('@/models/User', () => ({
   __esModule: true,
   default: mockUserModel,
 }));
 
-jest.mock('../dbConnect', () => ({
+jest.mock('@/lib/dbConnect', () => ({
   __esModule: true,
   default: mockDbConnect,
 }));

--- a/app-next-directory/src/lib/auth/serverAuth.ts
+++ b/app-next-directory/src/lib/auth/serverAuth.ts
@@ -7,8 +7,8 @@
 
 import { UserRole } from '@/types/auth';
 import bcrypt from 'bcryptjs';
-import User from '../../models/User';
-import dbConnect from '../dbConnect';
+import User from '@/models/User';
+import dbConnect from '@/lib/dbConnect';
 
 import { Types, isValidObjectId, type FilterQuery } from 'mongoose';
 import { isEmailVerificationRequired } from './config';

--- a/app-next-directory/src/lib/dbConnect.ts
+++ b/app-next-directory/src/lib/dbConnect.ts
@@ -34,7 +34,7 @@ async function dbConnect(): Promise<Mongoose> {
   // Dynamically load mongoose for mocking flexibility
   const mongoose: Mongoose = require('mongoose');
 
-  if (isE2E) {
+  if (isE2E || process.env.NODE_ENV === 'test') {
     if (!cached.conn) {
       cached.conn = mongoose;
       cached.promise = Promise.resolve(mongoose);


### PR DESCRIPTION
## Summary
- update the server-side auth module to import the User model and dbConnect helper through the shared path aliases so tests hit the mocked modules
- adjust the serverAuth unit test to mock those dependencies through the same aliases
- treat NODE_ENV="test" like the E2E flag in dbConnect so unit tests get a resolved mongoose instance without a real connection

## Testing
- `pnpm --filter app-next-directory test:unit -- src/__tests__/auth/next-auth-authentication.test.ts` *(fails: mockEnforceLoginRateLimit.mockResolvedValue is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68d4013000888323a1dcd32934369a0e