### PR TITLE
Fix search unit tests and Next.js response mocks

### DIFF
--- a/app-next-directory/app/api/auth/test/route.ts
+++ b/app-next-directory/app/api/auth/test/route.ts
@@ -1,6 +1,5 @@
 import { auth } from '@/lib/auth';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
-import { NextResponse } from 'next/dist/server/web/spec-extension/response';
+import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app-next-directory/app/api/blog/[slug]/route.ts
+++ b/app-next-directory/app/api/blog/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { client as sanityClient } from '@/lib/sanity/client';
 import { ApiResponseHandler } from '@/utils/api-response';
 import { groq } from 'next-sanity';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 import { transformToBlogDetailDTO } from '@/lib/dto-transformer';
 
 // GROQ query for fetching a single blog post by slug

--- a/app-next-directory/app/api/contact/route.ts
+++ b/app-next-directory/app/api/contact/route.ts
@@ -1,6 +1,6 @@
 import { ApiResponseHandler } from '@/utils/api-response';
 import { rateLimit } from '@/utils/rate-limit';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 import nodemailer from 'nodemailer';
 import { z } from 'zod';
 import { sendMail } from '@/lib/email';

--- a/app-next-directory/app/api/listings/[slug]/route.ts
+++ b/app-next-directory/app/api/listings/[slug]/route.ts
@@ -2,7 +2,7 @@ import { ApiResponseHandler } from '@/utils/api-response';
 import { handleAuthError, requireAuth } from '@/utils/auth-helpers';
 import { getCollection } from '@/utils/db-helpers';
 import { getListingBySlug } from '@/lib/sanity/queries';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 
 export async function GET(
   request: NextRequest,

--- a/app-next-directory/app/api/listings/featured/route.ts
+++ b/app-next-directory/app/api/listings/featured/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 import { getFeaturedListings } from '@/lib/sanity/queries';
 import { ApiResponseHandler } from '@/utils/api-response';
 

--- a/app-next-directory/app/api/mock-env/route.ts
+++ b/app-next-directory/app/api/mock-env/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 import { ApiResponseHandler } from '@/utils/api-response';
 
 type NodeEnv = 'development' | 'production' | 'test';

--- a/app-next-directory/app/api/revalidate/route.ts
+++ b/app-next-directory/app/api/revalidate/route.ts
@@ -1,5 +1,5 @@
 import { revalidatePath } from 'next/cache';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 import { ApiResponseHandler } from '@/utils/api-response';
 
 export const dynamic = 'force-dynamic';

--- a/app-next-directory/app/api/reviews/listing/[slug]/route.ts
+++ b/app-next-directory/app/api/reviews/listing/[slug]/route.ts
@@ -1,6 +1,6 @@
 import { ApiResponseHandler } from '@/utils/api-response';
 import { getCollection } from '@/utils/db-helpers';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 
 export async function GET(
   request: NextRequest,

--- a/app-next-directory/src/hooks/useSearch.test.tsx
+++ b/app-next-directory/src/hooks/useSearch.test.tsx
@@ -34,7 +34,7 @@ const TestComponent: React.FC<TestComponentProps> = ({ initialQuery = '' }) => {
       <span data-testid="results">{search.results.map((r) => r.name).join(', ')}</span>
       <button onClick={() => search.handleQueryChange('an')}>Set Query to an</button>
       <button onClick={() => search.handleQueryChange('xyz')}>Set Query to xyz</button>
-      <button onClick={() => search.handleQueryChange('  apple  ')}>Set Query to spaced apple</button>
+      <button onClick={() => search.handleQueryChange('  bangkok  ')}>Set Query to spaced bangkok</button>
       <button onClick={() => search.handleQueryChange('test')}>Set Query to test</button>
     </>
   );
@@ -57,7 +57,7 @@ describe('useSearch', () => {
       // Debug log for actual results
       // eslint-disable-next-line no-console
       console.log('Actual results:', screen.getByTestId('results').textContent);
-      expect(screen.getByTestId('results').textContent).toContain('Banana');
+      expect(screen.getByTestId('results').textContent).toContain('Bangkok Eco Hub');
     });
   });
 
@@ -90,18 +90,18 @@ describe('useSearch', () => {
     });
   });
 
-  it('should not trim the search term before filtering', async () => {
+  it('should handle search terms with surrounding whitespace', async () => {
     render(<TestComponent initialQuery="" />);
 
-    userEvent.click(screen.getByText('Set Query to spaced apple'));
+    userEvent.click(screen.getByText('Set Query to spaced bangkok'));
     await act(async () => {
       jest.advanceTimersByTime(350);
       await Promise.resolve();
     });
     await act(async () => { await Promise.resolve(); });
     await waitFor(() => {
-      expect(screen.getByTestId('query').textContent).toBe('  apple  ');
-      expect(screen.getByTestId('results').textContent).toContain('Apple');
+      expect(screen.getByTestId('query').textContent).toBe('  bangkok  ');
+      expect(screen.getByTestId('results').textContent).toContain('Bangkok Eco Hub');
     });
   });
 });

--- a/app-next-directory/src/lib/auth/withAuthMatrix.ts
+++ b/app-next-directory/src/lib/auth/withAuthMatrix.ts
@@ -1,7 +1,6 @@
 import { auth } from '@/lib/auth';
 import { getToken } from 'next-auth/jwt';
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
-import { NextResponse } from 'next/dist/server/web/spec-extension/response';
+import { NextRequest, NextResponse } from 'next/server';
 import {
     ACCESS_CONTROL_MATRIX,
     hasFeaturePermission,

--- a/app-next-directory/src/tests/mocks/factories.ts
+++ b/app-next-directory/src/tests/mocks/factories.ts
@@ -1,6 +1,6 @@
 // Mock factories for middleware tests
 
-import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import { NextRequest } from 'next/server';
 
 export function makeMockRequest(pathname: string): NextRequest {
   return {

--- a/app-next-directory/src/utils/api-response.ts
+++ b/app-next-directory/src/utils/api-response.ts
@@ -53,7 +53,7 @@ export interface ApiResponse<T = any> {
 
 export const ApiResponseHandler = {
   success: (data: any, message?: string) => {
-    const payload = message === undefined ? { success: true, data } : { success: true, data, message };
+    const payload = { success: true, data, ...(message !== undefined && { message }) };
     return createJsonResponse(payload);
   },
 

--- a/app-next-directory/src/utils/api-response.ts
+++ b/app-next-directory/src/utils/api-response.ts
@@ -16,7 +16,7 @@ function createJsonResponse(body: JsonBody, init?: ResponseInit) {
   const headers = new Headers(init?.headers ?? {});
   if (!headers.has('content-type')) headers.set('content-type', 'application/json');
 
-  if (typeof NextResponse?.json === 'function' && hasStaticResponseJson) {
+  if (typeof NextResponse?.json === 'function') {
     return NextResponse.json(body, { ...init, headers });
   }
 

--- a/app-next-directory/src/utils/api-response.ts
+++ b/app-next-directory/src/utils/api-response.ts
@@ -1,4 +1,47 @@
-import { NextResponse } from 'next/dist/server/web/spec-extension/response';
+import { NextResponse } from 'next/server';
+
+type JsonBody =
+  | Record<string, unknown>
+  | Array<unknown>
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+const hasStaticResponseJson =
+  typeof Response !== 'undefined' && typeof (Response as any).json === 'function';
+
+function createJsonResponse(body: JsonBody, init?: ResponseInit) {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+
+  if (typeof NextResponse?.json === 'function' && hasStaticResponseJson) {
+    return NextResponse.json(body, { ...init, headers });
+  }
+
+  const status = init?.status ?? 200;
+  const ok = status >= 200 && status < 300;
+  const textValue = typeof body === 'string' ? body : JSON.stringify(body ?? {});
+  const jsonValue =
+    typeof body === 'string'
+      ? (() => {
+          try {
+            return JSON.parse(body);
+          } catch {
+            return body;
+          }
+        })()
+      : body ?? {};
+
+  return {
+    status,
+    headers,
+    ok,
+    text: () => Promise.resolve(textValue),
+    json: () => Promise.resolve(jsonValue),
+  } as Response;
+}
 
 export interface ApiResponse<T = any> {
   success: boolean;
@@ -10,9 +53,8 @@ export interface ApiResponse<T = any> {
 
 export const ApiResponseHandler = {
   success: (data: any, message?: string) => {
-    return NextResponse.json(
-      { success: true, data, message }
-    );
+    const payload = message === undefined ? { success: true, data } : { success: true, data, message };
+    return createJsonResponse(payload);
   },
 
   error: (
@@ -22,26 +64,26 @@ export const ApiResponseHandler = {
   ) => {
     const payload: any = { success: false, error };
     if (details !== undefined) payload.details = details;
-    return NextResponse.json(payload, { status });
+    return createJsonResponse(payload, { status });
   },
 
   notFound: (resource?: string) => {
     const msg = resource ? `${resource} not found` : 'Resource not found';
-    return NextResponse.json(
+    return createJsonResponse(
       { success: false, error: msg },
       { status: 404 }
     );
   },
 
   unauthorized: () => {
-    return NextResponse.json(
+    return createJsonResponse(
       { success: false, error: 'Unauthorized access' },
       { status: 401 }
     );
   },
 
   forbidden: () => {
-    return NextResponse.json(
+    return createJsonResponse(
       { success: false, error: 'Forbidden' },
       { status: 403 }
     );


### PR DESCRIPTION
## Summary
- update shared API response helper to gracefully fall back when NextResponse.json is unavailable in the Jest environment
- standardize API route modules to import NextRequest/NextResponse from `next/server` so the shared mocks take effect in tests
- refresh the search hook test expectations to reflect the mock search data returned by the MSW handlers

## Testing
- `pnpm --filter app-next-directory exec:jest -- --runTestsByPath src/__tests__/api/search/route.test.ts`
- `pnpm --filter app-next-directory exec:jest -- --runTestsByPath src/hooks/useSearch.test.tsx`
- `pnpm --filter app-next-directory exec:jest -- --runTestsByPath src/__tests__/api/listings/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d4020e39a08323a5436b87f5bc0d5a