### PR TITLE
Fix API review responses for JSON compatibility

### DIFF
--- a/app-next-directory/src/utils/api-response.ts
+++ b/app-next-directory/src/utils/api-response.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from 'next/dist/server/web/spec-extension/response';
-
 export interface ApiResponse<T = any> {
   success: boolean;
   data?: T;
@@ -8,11 +6,30 @@ export interface ApiResponse<T = any> {
   details?: any;
 }
 
+function createJsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers ?? {});
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  });
+}
+
 export const ApiResponseHandler = {
   success: (data: any, message?: string) => {
-    return NextResponse.json(
-      { success: true, data, message }
-    );
+    const payload: ApiResponse = {
+      success: true,
+      data,
+    };
+
+    if (message !== undefined) {
+      payload.message = message;
+    }
+
+    return createJsonResponse(payload);
   },
 
   error: (
@@ -20,30 +37,24 @@ export const ApiResponseHandler = {
     status: number = 400,
     details?: unknown
   ) => {
-    const payload: any = { success: false, error };
-    if (details !== undefined) payload.details = details;
-    return NextResponse.json(payload, { status });
+    const payload: ApiResponse = { success: false, error };
+    if (details !== undefined) {
+      payload.details = details;
+    }
+
+    return createJsonResponse(payload, { status });
   },
 
   notFound: (resource?: string) => {
     const msg = resource ? `${resource} not found` : 'Resource not found';
-    return NextResponse.json(
-      { success: false, error: msg },
-      { status: 404 }
-    );
+    return createJsonResponse({ success: false, error: msg }, { status: 404 });
   },
 
   unauthorized: () => {
-    return NextResponse.json(
-      { success: false, error: 'Unauthorized access' },
-      { status: 401 }
-    );
+    return createJsonResponse({ success: false, error: 'Unauthorized access' }, { status: 401 });
   },
 
   forbidden: () => {
-    return NextResponse.json(
-      { success: false, error: 'Forbidden' },
-      { status: 403 }
-    );
+    return createJsonResponse({ success: false, error: 'Forbidden' }, { status: 403 });
   },
 };


### PR DESCRIPTION
## Summary
- replace NextResponse usage in ApiResponseHandler with a fetch-compatible JSON response helper so callers can consume .json()
- ensure review API handler returns parseable JSON payloads for listings review tests

## Testing
- pnpm test -- utils/__tests__/api-response.test.ts
- pnpm test -- /api/reviews

------
https://chatgpt.com/codex/tasks/task_e_68d402b04d1883239f650600cba3050b