### PR TITLE
Fix auth adapter and login invariant guards

### DIFF
--- a/app-next-directory/src/lib/auth/adapter.ts
+++ b/app-next-directory/src/lib/auth/adapter.ts
@@ -28,12 +28,3 @@ export function createAuthAdapter(): Adapter | undefined {
 
   return adapterFactory(clientPromise);
 }
-
-  const uri = process.env.MONGODB_URI;
-  if (typeof uri !== 'string' || uri.trim().length === 0) {
-    return undefined;
-  }
-
-  const adapterFactory = resolveAdapterFactory();
-  return adapterFactory(clientPromise);
-}

--- a/app-next-directory/src/models/LoginAttempt.ts
+++ b/app-next-directory/src/models/LoginAttempt.ts
@@ -239,6 +239,21 @@ const ensureUpdateInvariant = async function ensureUpdateInvariant(
         ),
       );
     }
+  }
+
+  if (reasonValue !== undefined && successValue === undefined) {
+    const conflictFilter: FilterQuery<ILoginAttempt> = {
+      $and: [
+        filter as FilterQuery<ILoginAttempt>,
+        reasonValue === SUCCESS_REASON ? { success: { $ne: true } } : { success: true },
+      ],
+    };
+
+    const lookupOptions = { ...this.getOptions(), upsert: false };
+    const conflict = await this.model.exists(conflictFilter).setOptions(lookupOptions);
+
+    if (conflict) {
+      return next(
         invariantError(
           'success',
           reasonValue === SUCCESS_REASON


### PR DESCRIPTION
## Summary
- remove the duplicated return block in the NextAuth Mongo adapter helper to restore valid syntax
- add the missing login attempt reason-only conflict check so update invariants remain well-formed

## Testing
- pnpm --filter app-next-directory exec:jest app/api/comments/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9a26f01f483239b600ca6c8c7dd00