### PR TITLE
Fix auth adapter syntax and register validation

### DIFF
--- a/app-next-directory/app/api/auth/register/route.ts
+++ b/app-next-directory/app/api/auth/register/route.ts
@@ -5,15 +5,39 @@ import bcrypt from 'bcryptjs';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { name, email, password } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 },
+      );
+    }
+
+    if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 },
+      );
+    }
+
+    const { name, email, password } = body as Partial<{ name: string; email: string; password: string }>;
+
+    // Validate required fields
+    if (!name || !email || !password) {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 }
+      );
+    }
 
     // Test mode: return fake user for tests
     if (process.env.TEST_MODE === '1') {
       const fakeUser = { _id: 'test-user-1', name, email, role: 'user' };
       return NextResponse.json(
         { success: true, data: { user: fakeUser }, error: null },
-        { status: 201, headers: { 'X-Test-Mode': '1' } }
+        { status: 201, headers: { 'X-Test-Mode': '1' } },
       );
     }
 
@@ -26,22 +50,14 @@ export async function POST(request: NextRequest) {
           data: null,
           error: {
             code: 'MISSING_DB_CONFIG',
-            message: 'MONGODB_URI not configured in environment; registration disabled in this environment'
-          }
+            message: 'MONGODB_URI not configured in environment; registration disabled in this environment',
+          },
         },
-        { status: 503, headers: { 'Retry-After': '60' } }
+        { status: 503, headers: { 'Retry-After': '60' } },
       );
     }
 
     await connect();
-
-    // Validate required fields
-    if (!name || !email || !password) {
-      return NextResponse.json(
-        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
-        { status: 400 }
-      );
-    }
 
     // Check if user already exists
     const existingUser = await User.findOne({ email });

--- a/app-next-directory/src/lib/auth/adapter.ts
+++ b/app-next-directory/src/lib/auth/adapter.ts
@@ -28,12 +28,3 @@ export function createAuthAdapter(): Adapter | undefined {
 
   return adapterFactory(clientPromise);
 }
-
-  const uri = process.env.MONGODB_URI;
-  if (typeof uri !== 'string' || uri.trim().length === 0) {
-    return undefined;
-  }
-
-  const adapterFactory = resolveAdapterFactory();
-  return adapterFactory(clientPromise);
-}

--- a/app-next-directory/src/models/LoginAttempt.ts
+++ b/app-next-directory/src/models/LoginAttempt.ts
@@ -239,6 +239,21 @@ const ensureUpdateInvariant = async function ensureUpdateInvariant(
         ),
       );
     }
+  }
+
+  if (reasonValue !== undefined && successValue === undefined) {
+    const conflictFilter: FilterQuery<ILoginAttempt> = {
+      $and: [
+        filter as FilterQuery<ILoginAttempt>,
+        reasonValue === SUCCESS_REASON ? { success: false } : { success: true },
+      ],
+    };
+
+    const lookupOptions = { ...this.getOptions(), upsert: false };
+    const conflict = await this.model.exists(conflictFilter).setOptions(lookupOptions);
+
+    if (conflict) {
+      return next(
         invariantError(
           'success',
           reasonValue === SUCCESS_REASON


### PR DESCRIPTION
## Summary
- remove duplicate return block from the NextAuth adapter implementation
- restore missing login attempt invariant check when updating reason without success
- harden the register API route to reject invalid or missing JSON bodies before hitting the database

## Testing
- `pnpm --filter app-next-directory test -- --runTestsByPath app/api/auth/register/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d9a24769688323b9aab5088143ae43