### PR TITLE
Add search form component and listings hook for search tests

### DIFF
--- a/app-next-directory/src/components/search/SearchForm.tsx
+++ b/app-next-directory/src/components/search/SearchForm.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { FormEvent, type KeyboardEvent, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSearchListings, type SearchListing, type SearchRequest } from '@/hooks/useSearchListings'
+
+interface SearchCategoryOption {
+  label: string
+  value: string
+}
+
+const CATEGORY_OPTIONS: SearchCategoryOption[] = [
+  { label: 'All categories', value: '' },
+  { label: 'Coworking', value: 'coworking' },
+  { label: 'Coliving', value: 'coliving' },
+  { label: 'Café', value: 'cafe' },
+  { label: 'Community Space', value: 'community' },
+]
+
+const FILTER_PRESETS = [
+  { key: 'solarPowered', label: 'Solar powered' },
+  { key: 'veganFriendly', label: 'Vegan friendly' },
+  { key: 'wifiIncluded', label: 'Reliable Wi-Fi' },
+]
+
+interface SearchResultsProps {
+  listings: SearchListing[]
+  totalCount: number
+  hasMore: boolean
+  onClearFilters: () => void
+}
+
+function SearchResults({ listings, totalCount, hasMore, onClearFilters }: SearchResultsProps) {
+  if (listings.length === 0) {
+    return (
+      <section
+        role="region"
+        aria-label="Search results"
+        aria-live="polite"
+        className="mt-6"
+        data-testid="empty-results"
+      >
+        <p className="text-sm text-muted-foreground">No results found</p>
+        <button type="button" className="mt-2 underline" onClick={onClearFilters}>
+          Clear filters
+        </button>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="Search results"
+      aria-live="polite"
+      className="mt-6 space-y-4"
+    >
+      <div role="status" className="font-medium" aria-live="polite" aria-label={`${totalCount} results found`}>
+        {totalCount} results found
+      </div>
+      <ul className="space-y-3">
+        {listings.map((listing) => (
+          <li key={listing.id} className="rounded border border-border p-3">
+            <h3 className="font-semibold">{listing.title}</h3>
+            {listing.city ? (
+              <p className="text-sm text-muted-foreground">{listing.city}</p>
+            ) : null}
+            {listing.category ? (
+              <p className="text-xs uppercase text-muted-foreground">{listing.category}</p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      {hasMore ? <p className="text-xs text-muted-foreground">More results available, refine your filters to narrow down.</p> : null}
+    </section>
+  )
+}
+
+export function SearchForm() {
+  const router = useRouter()
+  const { listings, loading, error, searchListings, totalCount, hasMore } = useSearchListings()
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState('')
+  const [filters, setFilters] = useState<Record<string, boolean>>({})
+  const [showFilters, setShowFilters] = useState(false)
+  const [lastParams, setLastParams] = useState<SearchRequest | null>(null)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const categorySelectRef = useRef<HTMLSelectElement | null>(null)
+  const filterButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  const activeFilters = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(filters).filter(([, isEnabled]) => isEnabled)
+    )
+  }, [filters])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const params: SearchRequest = {
+      query,
+      category: category || undefined,
+      filters: { ...activeFilters },
+    }
+    setLastParams(params)
+    void searchListings(params)
+
+    const segments: string[] = []
+    if (params.query) segments.push(`search=${encodeURIComponent(params.query)}`)
+    if (params.category) segments.push(`category=${encodeURIComponent(params.category)}`)
+    if (Object.keys(activeFilters).length) {
+      segments.push(`filters=${encodeURIComponent(JSON.stringify(activeFilters))}`)
+    }
+
+    const next = segments.join('&')
+    router.push(next ? `/search?${next}` : '/search')
+  }
+
+  const handleRetry = () => {
+    const params = lastParams ?? { query, category: category || undefined, filters: { ...activeFilters } }
+    setLastParams(params)
+    void searchListings(params)
+  }
+
+  const handleClearFilters = () => {
+    setCategory('')
+    setFilters({})
+    setLastParams({ query: '', filters: {} })
+    setQuery('')
+    void searchListings({ query: '', filters: {} })
+    router.push('/search')
+  }
+
+  const toggleFilter = (key: string) => {
+    setFilters((previous) => ({
+      ...previous,
+      [key]: !previous[key],
+    }))
+  }
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Tab') return
+    if (event.shiftKey) return
+    event.preventDefault()
+    categorySelectRef.current?.focus()
+  }
+
+  const handleCategoryKeyDown = (event: KeyboardEvent<HTMLSelectElement>) => {
+    if (event.key !== 'Tab') return
+    event.preventDefault()
+    if (event.shiftKey) {
+      searchInputRef.current?.focus()
+      return
+    }
+    filterButtonRef.current?.focus()
+  }
+
+  const handleFilterKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'Tab') return
+    if (!event.shiftKey) return
+    event.preventDefault()
+    categorySelectRef.current?.focus()
+  }
+
+  return (
+    <div className="w-full max-w-3xl">
+      <form
+        onSubmit={handleSubmit}
+        role="search"
+        aria-label="Search listings"
+        className="rounded-md border border-border bg-card p-4 shadow-sm"
+      >
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="search-input" className="text-sm font-medium">
+              Search for eco-friendly venues
+            </label>
+            <input
+              id="search-input"
+              name="search"
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              ref={searchInputRef}
+              placeholder="Find sustainable coworking, cafés, retreats..."
+              className="rounded border border-border px-3 py-2"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="category" className="text-sm font-medium">
+              Filter by venue category
+            </label>
+            <select
+              id="category"
+              name="category"
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+              onKeyDown={handleCategoryKeyDown}
+              ref={categorySelectRef}
+              className="rounded border border-border px-3 py-2"
+            >
+              {CATEGORY_OPTIONS.map((option) => (
+                <option key={option.value || 'all'} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setShowFilters((value) => !value)}
+              aria-expanded={showFilters}
+              className="text-sm font-medium underline"
+              onKeyDown={handleFilterKeyDown}
+              ref={filterButtonRef}
+            >
+              Filters
+            </button>
+            <button type="submit" className="rounded bg-primary px-4 py-2 text-primary-foreground">
+              Search
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <div
+        data-testid="filter-panel"
+        aria-hidden={!showFilters}
+        style={{ display: showFilters ? 'block' : 'none' }}
+        className="mt-4 rounded-md border border-dashed border-border p-4"
+      >
+        <p className="mb-2 text-sm font-semibold">Refine results</p>
+        <div className="flex flex-col gap-2">
+          {FILTER_PRESETS.map((filter) => (
+            <label key={filter.key} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={Boolean(filters[filter.key])}
+                onChange={() => toggleFilter(filter.key)}
+              />
+              {filter.label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="mt-6 flex items-center gap-2 text-sm text-muted-foreground" data-testid="search-loading">
+          <span className="animate-pulse">Searching...</span>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-6 rounded border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          <p>{error}</p>
+          <button type="button" className="mt-2 underline" onClick={handleRetry}>
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      <SearchResults
+        listings={listings}
+        totalCount={totalCount}
+        hasMore={hasMore}
+        onClearFilters={handleClearFilters}
+      />
+    </div>
+  )
+}
+
+export default SearchForm

--- a/app-next-directory/src/hooks/useSearchListings.ts
+++ b/app-next-directory/src/hooks/useSearchListings.ts
@@ -1,0 +1,143 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+type SearchFilters = Record<string, unknown>
+
+export interface SearchListing {
+  id: string
+  title: string
+  category?: string | null
+  city?: string | null
+  sustainabilityScore?: number | null
+  [key: string]: unknown
+}
+
+export interface SearchRequest {
+  query?: string
+  category?: string
+  filters?: SearchFilters
+  page?: number
+  limit?: number
+}
+
+export interface UseSearchListingsResult {
+  listings: SearchListing[]
+  loading: boolean
+  error: string | null
+  totalCount: number
+  hasMore: boolean
+  searchListings: (params?: SearchRequest) => Promise<void>
+}
+
+interface SearchResponseShape {
+  results?: unknown
+  total?: unknown
+  count?: unknown
+  pagination?: {
+    total?: unknown
+    page?: unknown
+    totalPages?: unknown
+    hasMore?: unknown
+  }
+}
+
+function coerceNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+function ensureArray(value: unknown): SearchListing[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is SearchListing => typeof entry === 'object' && entry !== null)
+  }
+  return []
+}
+
+export function useSearchListings(initialRequest: SearchRequest = {}): UseSearchListingsResult {
+  const [listings, setListings] = useState<SearchListing[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [totalCount, setTotalCount] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+
+  const initialRequestRef = useRef<SearchRequest>({ ...initialRequest })
+  const lastRequestRef = useRef<SearchRequest>({ ...initialRequest })
+
+  const searchListings = useCallback(async (params: SearchRequest = {}) => {
+    const merged: SearchRequest = {
+      ...initialRequestRef.current,
+      ...params,
+    }
+
+    lastRequestRef.current = merged
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: merged.query ?? '',
+          category: merged.category ?? '',
+          filters: merged.filters ?? {},
+          page: merged.page ?? 1,
+          limit: merged.limit ?? 12,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error(`Search request failed with status ${response.status}`)
+      }
+
+      const payload: SearchResponseShape = await response.json()
+      const nextListings = ensureArray(payload.results)
+      setListings(nextListings)
+
+      const totalFromResponse = coerceNumber(
+        payload.total ?? payload.count ?? payload.pagination?.total,
+        nextListings.length
+      )
+      setTotalCount(totalFromResponse)
+
+      const currentPage = coerceNumber(merged.page, 1)
+      const currentLimit = coerceNumber(merged.limit, nextListings.length || 1)
+      const derivedHasMore = Boolean(
+        payload.pagination?.hasMore ?? currentPage * currentLimit < totalFromResponse
+      )
+      setHasMore(derivedHasMore)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setError(message)
+      setListings([])
+      setTotalCount(0)
+      setHasMore(false)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const resetAndSearch = useCallback(async () => {
+    if (Object.keys(initialRequestRef.current).length === 0) return
+    await searchListings(initialRequestRef.current)
+  }, [searchListings])
+
+  // Provide a stable reference for future enhancements while avoiding unused warnings
+  void resetAndSearch
+  void lastRequestRef
+
+  return {
+    listings,
+    loading,
+    error,
+    totalCount,
+    hasMore,
+    searchListings,
+  }
+}


### PR DESCRIPTION
## Summary
- implement a SearchForm component with accessible controls, filter toggles, and state handling
- introduce a useSearchListings hook to fetch listings and expose loading, error, and pagination metadata

## Testing
- pnpm --filter app-next-directory exec jest --config=jest.config.cjs --runTestsByPath src/components/search/__tests__/SearchForm.unit.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9a253e0ec832396ca38b3382c123e