### PR TITLE
Fix auth adapter and login attempt invariant guards

### DIFF
--- a/app-next-directory/src/lib/auth/adapter.ts
+++ b/app-next-directory/src/lib/auth/adapter.ts
@@ -28,12 +28,3 @@ export function createAuthAdapter(): Adapter | undefined {
 
   return adapterFactory(clientPromise);
 }
-
-  const uri = process.env.MONGODB_URI;
-  if (typeof uri !== 'string' || uri.trim().length === 0) {
-    return undefined;
-  }
-
-  const adapterFactory = resolveAdapterFactory();
-  return adapterFactory(clientPromise);
-}

--- a/app-next-directory/src/models/LoginAttempt.ts
+++ b/app-next-directory/src/models/LoginAttempt.ts
@@ -239,6 +239,23 @@ const ensureUpdateInvariant = async function ensureUpdateInvariant(
         ),
       );
     }
+  }
+
+  if (reasonValue !== undefined && successValue === undefined) {
+    const conflictFilter: FilterQuery<ILoginAttempt> = {
+      $and: [
+        filter as FilterQuery<ILoginAttempt>,
+        reasonValue === SUCCESS_REASON
+          ? { success: { $ne: true } }
+          : { success: true },
+      ],
+    };
+
+    const lookupOptions = { ...this.getOptions(), upsert: false };
+    const conflict = await this.model.exists(conflictFilter).setOptions(lookupOptions);
+
+    if (conflict) {
+      return next(
         invariantError(
           'success',
           reasonValue === SUCCESS_REASON


### PR DESCRIPTION
## Summary
- remove the duplicate return block from the NextAuth adapter factory so the file parses correctly under SWC
- restore the missing invariant guard when only the login attempt reason is updated to keep success/reason combinations valid

## Testing
- pnpm test -- --runTestsByPath src/utils/__tests__/auth-helpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9a27a543483238f061d79e7dfa4a7