### PR TITLE
Fix Sanity client tests with environment restoration

### DIFF
--- a/app-next-directory/src/lib/sanity/client.test.ts
+++ b/app-next-directory/src/lib/sanity/client.test.ts
@@ -34,6 +34,7 @@ describe('Sanity client module', () => {
     create: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    getDocument: jest.fn(),
   };
 
   beforeEach(() => {
@@ -481,4 +482,9 @@ describe('Sanity client module', () => {
         token: 'partial-token',
         ignoreBrowserTokenWarning: true,
       });
-    }
+
+      process.env = originalEnv;
+    });
+
+  });
+});


### PR DESCRIPTION
## Summary
- add a mock implementation for `client.getDocument` in the Sanity client tests
- restore `process.env` and close remaining describe blocks in the partial env configuration test

## Testing
- pnpm test -- client.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9a2835a0c83238eaa92e17fbc9457