### PR TITLE
Fix login attempt update validation for reason-only updates

### DIFF
--- a/app-next-directory/src/models/LoginAttempt.ts
+++ b/app-next-directory/src/models/LoginAttempt.ts
@@ -239,6 +239,21 @@ const ensureUpdateInvariant = async function ensureUpdateInvariant(
         ),
       );
     }
+  } else if (reasonValue !== undefined && successValue === undefined) {
+    const conflictFilter: FilterQuery<ILoginAttempt> = {
+      $and: [
+        filter as FilterQuery<ILoginAttempt>,
+        reasonValue === SUCCESS_REASON
+          ? { success: { $ne: true } }
+          : { success: true },
+      ],
+    };
+
+    const lookupOptions = { ...this.getOptions(), upsert: false };
+    const conflict = await this.model.exists(conflictFilter).setOptions(lookupOptions);
+
+    if (conflict) {
+      return next(
         invariantError(
           'success',
           reasonValue === SUCCESS_REASON


### PR DESCRIPTION
## Summary
- prevent login attempts from keeping mismatched success and reason values when only one field is updated
- mirror the success-field conflict check for reason-only updates to maintain invariants

## Testing
- ❌ `pnpm --filter app-next-directory exec jest src/__tests__/auth/rate-limiting.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d9a28ccf0083239460fbf8759d2c84