### PR TITLE
Add src re-exports for auth test mocks

### DIFF
--- a/app-next-directory/src/__mocks__/handlers.ts
+++ b/app-next-directory/src/__mocks__/handlers.ts
@@ -1,0 +1,1 @@
+export * from '../../__mocks__/handlers';

--- a/app-next-directory/src/__mocks__/server.ts
+++ b/app-next-directory/src/__mocks__/server.ts
@@ -1,0 +1,1 @@
+export { server } from '../../__mocks__/server';


### PR DESCRIPTION
## Summary
- add a src-level MSW server re-export so tests importing from `@/__mocks__/server` resolve correctly
- expose the shared handlers through a src-level barrel to match the new import path expectations

## Testing
- pnpm --filter app-next-directory test -- src/__tests__/auth/auth-components.test.tsx *(fails: existing auth component expectations unrelated to module resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a2bf88648323ac9a0b47e074f8c9