### PR TITLE
Fix auth adapter handling and registration validation

### DIFF
--- a/app-next-directory/app/api/auth/register/route.ts
+++ b/app-next-directory/app/api/auth/register/route.ts
@@ -5,8 +5,39 @@ import bcrypt from 'bcryptjs';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { name, email, password } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      console.warn('[register] Failed to parse request body', error);
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 }
+      );
+    }
+
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 }
+      );
+    }
+
+    const { name, email, password } = body as Partial<{ name: string; email: string; password: string }>;
+    const missingRequiredField =
+      typeof name !== 'string' ||
+      typeof email !== 'string' ||
+      typeof password !== 'string' ||
+      name.trim().length === 0 ||
+      email.trim().length === 0 ||
+      password.trim().length === 0;
+
+    if (missingRequiredField) {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+        { status: 400 }
+      );
+    }
 
     // Test mode: return fake user for tests
     if (process.env.TEST_MODE === '1') {
@@ -34,14 +65,6 @@ export async function POST(request: NextRequest) {
     }
 
     await connect();
-
-    // Validate required fields
-    if (!name || !email || !password) {
-      return NextResponse.json(
-        { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
-        { status: 400 }
-      );
-    }
 
     // Check if user already exists
     const existingUser = await User.findOne({ email });

--- a/app-next-directory/src/lib/auth/adapter.ts
+++ b/app-next-directory/src/lib/auth/adapter.ts
@@ -22,18 +22,21 @@ export function createAuthAdapter(): Adapter | undefined {
   const isJestMockAdapter =
     typeof adapterFactory === 'function' && 'mock' in adapterFactory;
 
-  if (
+  const shouldSkipAdapter =
     (adapterFactory === MongoDBAdapter || isJestMockAdapter) &&
     isJestEnvironment &&
-    process.env.USE_REAL_MONGODB_FOR_TESTS !== '1'
-  ) {
-    return undefined;
+    process.env.USE_REAL_MONGODB_FOR_TESTS !== '1';
+
+  let resolvedAdapter: Adapter | undefined;
+
+  if (!shouldSkipAdapter) {
+    const uri = process.env.MONGODB_URI;
+    const hasValidUri = typeof uri === 'string' && uri.trim().length > 0;
+
+    if (hasValidUri) {
+      resolvedAdapter = adapterFactory(clientPromise);
+    }
   }
 
-  const uri = process.env.MONGODB_URI;
-  if (typeof uri !== 'string' || uri.trim().length === 0) {
-    return undefined;
-  }
-
-  return adapterFactory(clientPromise);
+  return resolvedAdapter;
 }


### PR DESCRIPTION
## Summary
- update the auth adapter factory to avoid early returns that SWC rejected during Jest compilation
- harden the registration route parsing logic to return 400 for malformed or missing payloads before hitting the database

## Testing
- pnpm test -- --runTestsByPath app/api/auth/register/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9ad36b8308323925970360ad6ba22