### PR TITLE
Fix Jest SWC TypeScript parser configuration

### DIFF
--- a/app-next-directory/jest.config.cjs
+++ b/app-next-directory/jest.config.cjs
@@ -40,9 +40,18 @@ module.exports = {
   },
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest', {
-      jsc: { transform: { react: { runtime: 'automatic' } } },
-      module: { type: 'es6' }
-    }]
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          tsx: true,
+          decorators: true,
+        },
+        transform: {
+          react: { runtime: 'automatic' },
+        },
+      },
+      module: { type: 'es6' },
+    }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testMatch: [


### PR DESCRIPTION
## Summary
- configure the Jest SWC transform to use the TypeScript parser so unit tests can import .ts modules

## Testing
- pnpm --filter app-next-directory test:unit *(fails: existing Jest suites continue to fail due to unrelated test expectations and environment-dependent checks)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ad6575f083239d878947464f4486