### PR TITLE
feat: redesign profile favorites showcase

### DIFF
--- a/app-next-directory/app/api/user/favorites/route.ts
+++ b/app-next-directory/app/api/user/favorites/route.ts
@@ -31,13 +31,42 @@ export async function GET() {
           _id,
           name,
           "slug": slug.current,
-          mainImage {
+          type,
+          category,
+          priceRange,
+          shortDescription,
+          primaryImage {
+            alt,
             asset -> {
-              url
+              url,
+              metadata {
+                dimensions {
+                  width,
+                  height
+                }
+              }
             }
           },
-          city -> {
+          mainImage {
+            asset -> {
+              url,
+              metadata {
+                dimensions {
+                  width,
+                  height
+                }
+              }
+            }
+          },
+          ecoFocusTags[] -> {
             name
+          },
+          digitalNomadFeatures[] -> {
+            name
+          },
+          city -> {
+            name,
+            country
           }
         },
         createdAt

--- a/app-next-directory/app/profile/FavoriteListingsShowcase.tsx
+++ b/app-next-directory/app/profile/FavoriteListingsShowcase.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowUpRight, ChevronDown, Heart, Leaf, MapPin, Sparkles } from 'lucide-react';
+
+import { NeoBadge } from '@/components/ui/neo-badge';
+import { NeoButton } from '@/components/ui/neo-button';
+
+import type { FavoriteListing } from './utils';
+import { formatDate } from './utils';
+
+interface FavoriteListingsShowcaseProps {
+  listings: FavoriteListing[];
+}
+
+const ACCENT_GRADIENTS = [
+  'from-[#FEE2E2] via-neo-surface/70 to-[#FEF3C7]',
+  'from-[#DCFCE7] via-neo-surface/70 to-[#BFDBFE]',
+  'from-[#FBCFE8] via-neo-surface/70 to-[#DDD6FE]',
+  'from-[#FEF9C3] via-neo-surface/70 to-[#FDE68A]',
+  'from-[#CFFAFE] via-neo-surface/70 to-[#A5B4FC]',
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  coworking: 'Coworking Space',
+  cafe: 'Cafe',
+  accommodation: 'Accommodation',
+  restaurant: 'Restaurant',
+  activities: 'Activities',
+};
+
+const PRICE_RANGE_LABELS: Record<string, string> = {
+  budget: 'Budget Friendly',
+  moderate: 'Moderate',
+  premium: 'Premium',
+};
+
+function toLabel(value: string | undefined, dictionary: Record<string, string>): string | undefined {
+  if (!value) return undefined;
+  if (dictionary[value]) return dictionary[value];
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+export function FavoriteListingsShowcase({ listings }: FavoriteListingsShowcaseProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (listings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      {listings.map((listing, index) => {
+        const isExpanded = expandedId === listing.id;
+        const panelId = `favorite-panel-${listing.id}`;
+        const accentGradient = ACCENT_GRADIENTS[index % ACCENT_GRADIENTS.length];
+        const categoryLabel = toLabel(listing.category ?? listing.type, CATEGORY_LABELS);
+        const priceLabel = toLabel(listing.priceRange, PRICE_RANGE_LABELS);
+        const highlightTags = [
+          ...listing.ecoFocusTags.slice(0, 2),
+          ...listing.digitalNomadFeatures.slice(0, 2),
+        ];
+        const description =
+          listing.shortDescription ??
+          'This listing hasn\'t added a short description yet. Visit the listing page to explore more details about the experience.';
+
+        return (
+          <article
+            key={listing.id}
+            className="neo-card relative overflow-hidden rounded-3xl bg-neo-surface/95 p-6 transition-transform duration-150 hover:-translate-y-1 focus-within:-translate-y-1"
+          >
+            <div
+              className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${accentGradient} opacity-70`}
+              aria-hidden="true"
+            />
+            <div className="relative z-10 flex flex-col gap-6 lg:flex-row">
+              <div className="relative w-full max-w-[18rem] overflow-hidden rounded-2xl border-4 border-neo-border bg-neo-secondary/40 shadow-[6px_6px_0px_0px_var(--color-neo-shadow)] lg:w-64">
+                {listing.image ? (
+                  <Image
+                    src={listing.image.url}
+                    alt={listing.image.alt ?? `${listing.name} preview`}
+                    width={listing.image.width}
+                    height={listing.image.height}
+                    className="h-48 w-full object-cover"
+                    sizes="(max-width: 1024px) 60vw, 256px"
+                  />
+                ) : (
+                  <div className="flex h-48 w-full items-center justify-center bg-neo-secondary/50 text-neo-text-primary">
+                    <Heart className="h-12 w-12" aria-hidden="true" />
+                    <span className="sr-only">No preview image available</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex-1 space-y-5">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <h3 className="heading-sm text-neo-text-primary">{listing.name}</h3>
+                      {categoryLabel && (
+                        <NeoBadge size="sm" variant="secondary">
+                          {categoryLabel}
+                        </NeoBadge>
+                      )}
+                      {priceLabel && (
+                        <NeoBadge size="sm" variant="accent">
+                          {priceLabel}
+                        </NeoBadge>
+                      )}
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-4 text-sm text-neo-text-secondary">
+                      {listing.city && (
+                        <span className="inline-flex items-center gap-2 font-semibold text-neo-text-primary">
+                          <MapPin className="h-4 w-4" aria-hidden="true" />
+                          {listing.city}
+                          {listing.country ? `, ${listing.country}` : ''}
+                        </span>
+                      )}
+                      {listing.createdAt && (
+                        <span className="rounded-full border-4 border-neo-border bg-neo-secondary/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-neo-text-primary shadow-[3px_3px_0px_0px_var(--color-neo-shadow)]">
+                          Saved {formatDate(listing.createdAt)}
+                        </span>
+                      )}
+                    </div>
+
+                    {listing.shortDescription && (
+                      <p className="max-w-prose text-sm text-neo-text-secondary sm:text-base">
+                        {listing.shortDescription}
+                      </p>
+                    )}
+                  </div>
+
+                  <NeoButton
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setExpandedId((current) => (current === listing.id ? null : listing.id))}
+                    aria-expanded={isExpanded}
+                    aria-controls={panelId}
+                    className="gap-2 self-start"
+                  >
+                    <span>{isExpanded ? 'Hide details' : 'View details'}</span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                      aria-hidden="true"
+                    />
+                  </NeoButton>
+                </div>
+
+                {highlightTags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {highlightTags.map((tag, tagIndex) => (
+                      <NeoBadge
+                        key={`${listing.id}-highlight-${tag}-${tagIndex}`}
+                        variant="outline"
+                        size="sm"
+                        className="bg-white/75"
+                      >
+                        {tag}
+                      </NeoBadge>
+                    ))}
+                  </div>
+                )}
+
+                <div
+                  id={panelId}
+                  aria-hidden={!isExpanded}
+                  className={`grid gap-4 overflow-hidden transition-all duration-300 ${
+                    isExpanded ? 'max-h-[600px] opacity-100' : 'pointer-events-none max-h-0 opacity-0'
+                  } ${isExpanded ? 'mt-1' : ''}`}
+                >
+                  <div className="rounded-2xl border-4 border-neo-border bg-neo-surface/85 p-4 shadow-[4px_4px_0px_0px_var(--color-neo-shadow)]">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-neo-text-primary">Why we love it</h4>
+                    <p className="mt-3 text-sm text-neo-text-secondary">{description}</p>
+                  </div>
+
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="rounded-2xl border-4 border-neo-border bg-neo-surface/85 p-4 shadow-[4px_4px_0px_0px_var(--color-neo-shadow)]">
+                      <h5 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-neo-text-primary">
+                        <Leaf className="h-4 w-4" aria-hidden="true" /> Eco focus
+                      </h5>
+                      {listing.ecoFocusTags.length > 0 ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {listing.ecoFocusTags.map((tag) => (
+                            <NeoBadge key={`eco-${listing.id}-${tag}`} variant="success" size="sm">
+                              {tag}
+                            </NeoBadge>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="mt-3 text-sm text-neo-text-secondary">No eco focus tags yet.</p>
+                      )}
+                    </div>
+
+                    <div className="rounded-2xl border-4 border-neo-border bg-neo-surface/85 p-4 shadow-[4px_4px_0px_0px_var(--color-neo-shadow)]">
+                      <h5 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-neo-text-primary">
+                        <Sparkles className="h-4 w-4" aria-hidden="true" /> Nomad-friendly perks
+                      </h5>
+                      {listing.digitalNomadFeatures.length > 0 ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {listing.digitalNomadFeatures.map((feature) => (
+                            <NeoBadge key={`nomad-${listing.id}-${feature}`} variant="secondary" size="sm">
+                              {feature}
+                            </NeoBadge>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="mt-3 text-sm text-neo-text-secondary">No digital nomad features listed yet.</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border-4 border-neo-border bg-neo-surface/90 p-4 shadow-[4px_4px_0px_0px_var(--color-neo-shadow)]">
+                    <p className="text-sm text-neo-text-secondary">
+                      See photos, amenities, and availability on the listing page.
+                    </p>
+                    <NeoButton asChild size="sm" className="gap-2">
+                      <Link href={`/listings/${listing.slug}`}>
+                        View listing
+                        <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                      </Link>
+                    </NeoButton>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/app-next-directory/app/profile/page.tsx
+++ b/app-next-directory/app/profile/page.tsx
@@ -26,6 +26,7 @@ import {
   type FavoritesResponse,
   type OwnerReviewsResponse,
 } from './utils';
+import { FavoriteListingsShowcase } from './FavoriteListingsShowcase';
 
 export default function ProfilePage() {
   const { data: session, status, update } = useSession();
@@ -130,11 +131,6 @@ export default function ProfilePage() {
       .join('')
       .slice(0, 2);
   }, [session?.user?.name, session?.user?.email]);
-
-  const favoriteDateFormatter = useMemo(
-    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }),
-    []
-  );
 
   return (
     <div className="min-h-screen bg-background">
@@ -271,46 +267,7 @@ export default function ProfilePage() {
                   </NeoCardContent>
                 </NeoCard>
               ) : (
-                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                  {favorites.map((favorite) => (
-                    <NeoCard key={favorite.id} variant="flat" className="bg-white/95" data-testid="favorite-item">
-                      <NeoCardContent className="space-y-4">
-                        <div className="relative h-40 w-full overflow-hidden rounded-xl border-2 border-neo-border bg-neo-surface">
-                          {favorite.imageUrl ? (
-                            <Image
-                              src={favorite.imageUrl}
-                              alt={`${favorite.name} preview`}
-                              fill
-                              sizes="(max-width: 768px) 100vw, 33vw"
-                              className="object-cover"
-                            />
-                          ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-neo-secondary/60 text-neo-text-primary">
-                              <MapPin className="h-8 w-8" aria-hidden="true" />
-                            </div>
-                          )}
-                        </div>
-                        <div className="space-y-2">
-                          <h3 className="text-lg font-semibold text-neo-text-primary">{favorite.name}</h3>
-                          {favorite.city && (
-                            <p className="text-sm text-neo-text-secondary flex items-center gap-1">
-                              <MapPin className="h-4 w-4" aria-hidden="true" />
-                              {favorite.city}
-                            </p>
-                          )}
-                          {favorite.createdAt && (
-                            <p className="text-xs text-neo-text-secondary">
-                              Saved on {favoriteDateFormatter.format(new Date(favorite.createdAt))}
-                            </p>
-                          )}
-                        </div>
-                        <NeoButton asChild variant="secondary" size="sm">
-                          <Link href={`/listings/${favorite.slug}`}>View listing</Link>
-                        </NeoButton>
-                      </NeoCardContent>
-                    </NeoCard>
-                  ))}
-                </div>
+                <FavoriteListingsShowcase listings={favorites} />
               )}
             </section>
 

--- a/app-next-directory/app/profile/utils.ts
+++ b/app-next-directory/app/profile/utils.ts
@@ -1,10 +1,24 @@
 
+export interface FavoriteListingImage {
+  url: string;
+  alt?: string;
+  width: number;
+  height: number;
+}
+
 export interface FavoriteListing {
   id: string;
   name: string;
   slug: string;
   city?: string;
-  imageUrl?: string;
+  country?: string;
+  image?: FavoriteListingImage;
+  shortDescription?: string;
+  type?: string;
+  category?: string;
+  priceRange?: string;
+  ecoFocusTags: string[];
+  digitalNomadFeatures: string[];
   createdAt?: string;
 }
 
@@ -29,14 +43,43 @@ export type FavoriteEntry = {
     _id?: string;
     name?: string;
     slug?: string;
+    type?: string;
+    category?: string;
+    priceRange?: string;
+    shortDescription?: string;
     mainImage?: {
       asset?: {
         url?: string;
+        metadata?: {
+          dimensions?: {
+            width?: number;
+            height?: number;
+          };
+        };
+      } | null;
+    } | null;
+    primaryImage?: {
+      alt?: string;
+      asset?: {
+        url?: string;
+        metadata?: {
+          dimensions?: {
+            width?: number;
+            height?: number;
+          };
+        };
       } | null;
     } | null;
     city?: {
       name?: string;
+      country?: string;
     } | null;
+    ecoFocusTags?: Array<{
+      name?: string;
+    } | null> | null;
+    digitalNomadFeatures?: Array<{
+      name?: string;
+    } | null> | null;
   } | null;
   createdAt?: string;
 };
@@ -49,9 +92,86 @@ export interface OwnerReviewsResponse {
   listings?: OwnerListingReviews[];
 }
 
+function appendImageParams(url: string, width?: number, height?: number): string {
+  try {
+    const parsed = new URL(url);
+    const targetWidth = width && Number.isFinite(width) ? Math.round(width) : 640;
+    const targetHeight = height && Number.isFinite(height) ? Math.round(height) : 400;
+    parsed.searchParams.set('w', String(targetWidth));
+    parsed.searchParams.set('h', String(targetHeight));
+    parsed.searchParams.set('fit', 'crop');
+    parsed.searchParams.set('auto', 'format');
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+type SanityImageLike =
+  | {
+      alt?: string;
+      asset?: {
+        url?: string;
+        metadata?: {
+          dimensions?: {
+            width?: number;
+            height?: number;
+          };
+        };
+      } | null;
+    }
+  | null
+  | undefined;
+
+function normaliseImage(image: SanityImageLike): FavoriteListingImage | undefined {
+  if (!image || typeof image !== 'object') {
+    return undefined;
+  }
+
+  const alt = typeof (image as { alt?: unknown }).alt === 'string' ? (image as { alt?: string }).alt : undefined;
+  const asset = (image as { asset?: unknown }).asset as
+    | {
+        url?: unknown;
+        metadata?: {
+          dimensions?: {
+            width?: unknown;
+            height?: unknown;
+          };
+        };
+      }
+    | undefined;
+
+  const url = typeof asset?.url === 'string' && asset.url.length > 0 ? asset.url : undefined;
+  if (!url) {
+    return undefined;
+  }
+
+  const width = Number(asset?.metadata?.dimensions?.width);
+  const height = Number(asset?.metadata?.dimensions?.height);
+  const parsedWidth = Number.isFinite(width) && width > 0 ? Math.round(width) : 640;
+  const parsedHeight = Number.isFinite(height) && height > 0 ? Math.round(height) : 400;
+
+  return {
+    url: appendImageParams(url, parsedWidth, parsedHeight),
+    alt,
+    width: parsedWidth,
+    height: parsedHeight,
+  };
+}
+
+function normaliseStringArray(values: Array<{ name?: string } | null> | null | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return values
+    .map((value) => (typeof value?.name === 'string' ? value.name.trim() : ''))
+    .filter((value): value is string => value.length > 0);
+}
+
 export function normaliseFavorite(entry: FavoriteEntry | undefined): FavoriteListing | null {
   if (!entry) return null;
-    const listing = entry.listing;
+  const listing = entry.listing;
   const slug = typeof listing?.slug === 'string' ? listing.slug : '';
   if (!slug) return null;
   const name = typeof listing?.name === 'string' && listing.name.trim().length > 0
@@ -59,17 +179,32 @@ export function normaliseFavorite(entry: FavoriteEntry | undefined): FavoriteLis
     : 'Untitled listing';
 
   const city = typeof listing?.city?.name === 'string' ? listing.city.name : undefined;
-  const imageUrl =
-    typeof listing?.mainImage?.asset?.url === 'string' && listing.mainImage.asset.url.length > 0
-      ? listing.mainImage.asset.url
+  const country = typeof listing?.city?.country === 'string' ? listing.city.country : undefined;
+  const image =
+    normaliseImage(listing?.primaryImage ?? listing?.mainImage ?? undefined);
+  const shortDescription =
+    typeof listing?.shortDescription === 'string' && listing.shortDescription.trim().length > 0
+      ? listing.shortDescription.trim()
       : undefined;
+  const type = typeof listing?.type === 'string' ? listing.type : undefined;
+  const category = typeof listing?.category === 'string' ? listing.category : undefined;
+  const priceRange = typeof listing?.priceRange === 'string' ? listing.priceRange : undefined;
+  const ecoFocusTags = normaliseStringArray(listing?.ecoFocusTags);
+  const digitalNomadFeatures = normaliseStringArray(listing?.digitalNomadFeatures);
 
   return {
     id: entry._id ?? slug,
     name,
     slug,
     city,
-    imageUrl,
+    country,
+    image,
+    shortDescription,
+    type,
+    category,
+    priceRange,
+    ecoFocusTags,
+    digitalNomadFeatures,
     createdAt: typeof entry.createdAt === 'string' ? entry.createdAt : undefined,
   };
 }


### PR DESCRIPTION
## Summary
- replace the profile favorites grid with a neo-brutalist showcase component that surfaces saved listing imagery, location, and metadata
- normalize favorite listings to expose Sanity primary images, descriptive copy, and sustainability tags for the new UI
- expand the favorites API query to fetch primary image details, eco focus tags, and digital nomad features from Sanity

## Testing
- pnpm --filter app-next-directory lint


------
https://chatgpt.com/codex/tasks/task_e_68dfbefdcf088323acc171798ea247ca