### PR TITLE
fix: restore favorite removal and profile fetch

### DIFF
--- a/app-next-directory/app/api/user/favorites/[slug]/route.ts
+++ b/app-next-directory/app/api/user/favorites/[slug]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { auth } from '@/lib/auth';
 import { client } from '@/lib/sanity/client';
 import type { UserRole } from '@/types/auth';
-import { ensureSanityUser } from '@/lib/sanity/user';
+import { ensureSanityUser, unfavoriteListing } from '@/lib/sanity/user';
 
 interface RouteContext {
   params: Promise<{ slug: string }>;

--- a/app-next-directory/app/api/user/profile/route.ts
+++ b/app-next-directory/app/api/user/profile/route.ts
@@ -5,7 +5,7 @@ import { auth } from '@/lib/auth';
  * API route to get current user profile
  * This runs in Node.js runtime (not Edge) to allow MongoDB operations
  */
-export async function getUserProfile(request: Request) {
+export async function GET(request: Request) {
   try {
     // Get session (works in API routes with Node.js runtime)
     const session = await auth();


### PR DESCRIPTION
## Summary
- import the Sanity helper used by the favorite deletion API so unfavoriting works again
- expose the GET handler for the user profile API to prevent timeouts when loading profile data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfea0d28fc8323bebbfb3f497c28f7