### PR TITLE
Add Redis-backed rate limiting for contact API

### DIFF
--- a/app-next-directory/src/utils/__tests__/rate-limit.test.ts
+++ b/app-next-directory/src/utils/__tests__/rate-limit.test.ts
@@ -2,22 +2,35 @@
  * @jest-environment node
  */
 
-import { describe, it, expect, beforeEach, afterEach, jest, beforeAll } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+const mockRedisClient = {
+  incr: jest.fn(),
+  expire: jest.fn(),
+  del: jest.fn(),
+  get: jest.fn(),
+  ping: jest.fn(),
+  set: jest.fn(),
+};
+
+jest.mock('@/lib/redis', () => ({
+  __esModule: true,
+  getRedisClient: jest.fn(() => mockRedisClient),
+}));
+
+import { getRedisClient } from '@/lib/redis';
 import { rateLimit, rateLimiters, rateLimitStore } from '../rate-limit';
 
+const mockedGetRedisClient = getRedisClient as jest.Mock;
+
 describe('rate-limit', () => {
-  // Store original env vars
-  const originalEnv = { ...process.env };
-  
-  beforeAll(() => {
-    // Ensure Redis is not initialized during tests
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
-  });
-  
   beforeEach(() => {
     // Clear the rate limit store before each test
     rateLimitStore.clear();
+    jest.clearAllMocks();
+    mockedGetRedisClient.mockReturnValue(undefined);
+    mockRedisClient.incr.mockReset();
+    mockRedisClient.expire.mockReset();
     // Mock console.log to avoid noise in test output
     jest.spyOn(console, 'log').mockImplementation(() => {});
     // Mock console.warn to avoid noise from Redis initialization
@@ -26,11 +39,47 @@ describe('rate-limit', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    // Restore env vars
-    process.env = { ...originalEnv };
   });
 
   describe('rateLimit', () => {
+    it('uses Redis to persist counters when available', async () => {
+      mockedGetRedisClient.mockReturnValue(mockRedisClient);
+      mockRedisClient.incr.mockResolvedValueOnce(1);
+      mockRedisClient.expire.mockResolvedValueOnce(1);
+
+      const limiter = rateLimit({ max: 2, windowMs: 1000 });
+      const request = new Request('http://localhost', {
+        headers: { 'x-forwarded-for': '203.0.113.1' },
+      });
+
+      const result1 = await limiter(request);
+      expect(result1.success).toBe(true);
+      expect(mockRedisClient.incr).toHaveBeenCalledWith('rate-limit:203.0.113.1:1000');
+      expect(mockRedisClient.expire).toHaveBeenCalledWith('rate-limit:203.0.113.1:1000', 1);
+
+      mockRedisClient.incr.mockResolvedValueOnce(3);
+
+      const blocked = await limiter(request);
+      expect(blocked.success).toBe(false);
+      expect(blocked.remaining).toBe(0);
+    });
+
+    it('falls back to in-memory when Redis throws', async () => {
+      mockedGetRedisClient.mockReturnValue(mockRedisClient);
+      mockRedisClient.incr.mockRejectedValueOnce(new Error('redis error'));
+
+      const limiter = rateLimit({ max: 1, windowMs: 1000 });
+      const request = new Request('http://localhost', {
+        headers: { 'x-forwarded-for': '198.51.100.2' },
+      });
+
+      const result1 = await limiter(request);
+      expect(result1.success).toBe(true);
+
+      const result2 = await limiter(request);
+      expect(result2.success).toBe(false);
+    });
+
     it('should allow requests within the limit', async () => {
       const limiter = rateLimit({ max: 3, windowMs: 1000 });
       const request = new Request('http://localhost', {

--- a/app-next-directory/src/utils/rate-limit.ts
+++ b/app-next-directory/src/utils/rate-limit.ts
@@ -1,27 +1,38 @@
 /**
- * Rate Limiting Utility
- * Uses Redis-based rate limiting via @upstash/ratelimit with in-memory fallback
+ * Redis-backed rate limiting utility with in-memory fallback.
+ *
+ * Uses Upstash Redis (via REST client) when available to persist counters across
+ * deployments and processes. Falls back to an in-memory Map when Redis is
+ * unavailable so that local development and tests still work.
  */
 
-import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
+import type { RedisLike } from '@/lib/redis';
+import { getRedisClient } from '@/lib/redis';
 
+export interface RateLimitOptions {
+  max: number; // Maximum requests allowed in the window
+  windowMs: number; // Duration of the window in milliseconds
+  keyGenerator?: (request: Request) => string; // Optional custom key builder
+}
 
- * Uses Redis-based rate limiting via @upstash/ratelimit with in-memory fallback
- */
-
-import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
+export interface RateLimitResult {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  resetTime: number;
+}
 
 interface RateLimitInfo {
   count: number;
   resetTime: number;
 }
 
-// In-memory store for rate limiting (fallback when Redis is not available)
+const RATE_LIMIT_PREFIX = 'rate-limit';
+
+// In-memory store for fallback mode
 const rateLimitStore = new Map<string, RateLimitInfo>();
 
-// Clean up expired entries every 10 minutes (only for in-memory fallback)
+// Clean up expired entries every 10 minutes in the fallback store
 const cleanupInterval = setInterval(() => {
   const now = Date.now();
   for (const [key, info] of rateLimitStore.entries()) {
@@ -30,195 +41,9 @@ const cleanupInterval = setInterval(() => {
     }
   }
 }, 10 * 60 * 1000);
-
 cleanupInterval.unref?.();
 
-/**
- * Configuration options for rate limiting
- */
-// Initialize Redis client if credentials are available
-let redis: Redis | null = null;
-
-function initializeRedis() {
-  if (redis !== undefined) {
-    return redis;
-  }
-  
-  const UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL;
-  const UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
-
-  if (UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN) {
-    try {
-      redis = new Redis({
-        url: UPSTASH_REDIS_REST_URL,
-        token: UPSTASH_REDIS_REST_TOKEN,
-      });
-    } catch (error) {
-      console.warn('[rate-limit] Failed to initialize Redis, falling back to in-memory:', error);
-      redis = null;
-    }
-  } else {
-    console.warn('[rate-limit] Redis credentials not configured (UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN). Using in-memory rate limiting.');
-    redis = null;
-  }
-  
-  return redis;
-}
-
-export interface RateLimitOptions {
-  max: number; // Maximum requests
-  windowMs: number; // Time window in milliseconds
-  keyGenerator?: (request: Request) => string; // Custom key generator
-}
-
-/**
- * Result of a rate limit check
- */
-export interface RateLimitResult {
-  success: boolean;
-  limit: number;
-  remaining: number;
-  resetTime: number;
-}
-
-/**
- * In-memory rate limiting fallback
- */
-function inMemoryRateLimit(key: string, max: number, windowMs: number): RateLimitResult {
-  const now = Date.now();
-  const resetTime = now + windowMs;
-
-  // Get or create rate limit info
-  let info = rateLimitStore.get(key);
-
-  if (!info || now > info.resetTime) {
-    // Create new or reset expired
-    info = { count: 0, resetTime };
-    rateLimitStore.set(key, info);
-  }
-
-  // Check if limit exceeded
-  console.log('Key:', key, 'Count:', info ? info.count : 0);
-  if (info.count >= max) {
-    return {
-      success: false,
-      limit: max,
-      remaining: 0,
-      resetTime: info.resetTime,
-    };
-  }
-
-  // Increment count
-  info.count++;
-
-  return {
-    success: true,
-    limit: max,
-    remaining: max - info.count,
-    resetTime: info.resetTime,
-  };
-}
-
-/**
- * Rate limiting function
- * Uses Redis when available, falls back to in-memory
- * In-memory rate limiting fallback
- */
-function inMemoryRateLimit(key: string, max: number, windowMs: number): RateLimitResult {
-  const now = Date.now();
-  const resetTime = now + windowMs;
-
-  // Get or create rate limit info
-  let info = rateLimitStore.get(key);
-
-  if (!info || now > info.resetTime) {
-    // Create new or reset expired
-    info = { count: 0, resetTime };
-    rateLimitStore.set(key, info);
-  }
-
-  // Check if limit exceeded
-  console.log('Key:', key, 'Count:', info ? info.count : 0);
-  if (info.count >= max) {
-    return {
-      success: false,
-      limit: max,
-      remaining: 0,
-      resetTime: info.resetTime,
-    };
-  }
-
-  // Increment count
-  info.count++;
-
-  return {
-    success: true,
-    limit: max,
-    remaining: max - info.count,
-    resetTime: info.resetTime,
-  };
-}
-
-/**
- * Rate limiting function
- * Uses Redis when available, falls back to in-memory
- */
-export function rateLimit(options: RateLimitOptions) {
-  const { max, windowMs, keyGenerator } = options;
-
-  // Lazy initialize Redis
-  const redisClient = initializeRedis();
-
-  // If Redis is available, create a Redis-based rate limiter
-  if (redisClient) {
-    const limiter = new Ratelimit({
-      redis: redisClient,
-      limiter: Ratelimit.slidingWindow(max, `${windowMs} ms`),
-      analytics: false, // Disable analytics for better performance
-    });
-
-    return async (request: Request): Promise<RateLimitResult> => {
-      try {
-        // Generate key for rate limiting (default to IP)
-        const key = keyGenerator ? keyGenerator(request) : getClientIP(request);
-        
-        const { success, limit, remaining, reset } = await limiter.limit(key);
-        
-        return {
-          success,
-          limit,
-          remaining,
-          resetTime: reset,
-        };
-      } catch (error) {
-        console.warn('[rate-limit] Redis error, falling back to in-memory:', error);
-        // Fallback to in-memory on error
-        const key = keyGenerator ? keyGenerator(request) : getClientIP(request);
-        return inMemoryRateLimit(key, max, windowMs);
-      }
-    };
-  }
-
-  // In-memory fallback
-  return async (request: Request): Promise<RateLimitResult> => {
-    const key = keyGenerator ? keyGenerator(request) : getClientIP(request);
-    return inMemoryRateLimit(key, max, windowMs);
-  };
-}
-
-/**
- * Extracts the client IP address from the request headers.
- * 
- * Checks multiple common headers used by proxies and load balancers:
- * - x-forwarded-for (first IP in the list)
- * - x-real-ip
- * - cf-connecting-ip (Cloudflare)
- * 
- * @param request - The incoming HTTP request
- * @returns The client IP address, or 'unknown' if none found
- */
-function getClientIP(request: Request): string {
-  // Try various headers for IP address
+const getClientIP = (request: Request): string => {
   const forwarded = request.headers.get('x-forwarded-for');
   if (forwarded) {
     const [first] = forwarded.split(',');
@@ -237,32 +62,108 @@ function getClientIP(request: Request): string {
     return cfConnectingIP;
   }
 
-  // Fallback to a default if no IP found
   return 'unknown';
+};
+
+const redisRateLimit = async (
+  redis: RedisLike,
+  key: string,
+  max: number,
+  windowMs: number
+): Promise<RateLimitResult> => {
+  const ttlSeconds = Math.ceil(windowMs / 1000);
+  const redisKey = `${RATE_LIMIT_PREFIX}:${key}:${windowMs}`;
+
+  const count = await redis.incr(redisKey);
+
+  if (count === 1) {
+    // First hit in the window – start the expiration timer.
+    await redis.expire(redisKey, ttlSeconds);
+  }
+
+  const remaining = Math.max(0, max - count);
+
+  return {
+    success: count <= max,
+    limit: max,
+    remaining,
+    // We do not have millisecond-precise TTL from Upstash here, so approximate
+    // using the configured window length.
+    resetTime: Date.now() + windowMs,
+  };
+};
+
+const inMemoryRateLimit = (key: string, max: number, windowMs: number): RateLimitResult => {
+  const now = Date.now();
+  const resetTime = now + windowMs;
+
+  const info = rateLimitStore.get(key);
+  const activeInfo = !info || now > info.resetTime ? { count: 0, resetTime } : info;
+
+  if (!info || now > info.resetTime) {
+    rateLimitStore.set(key, activeInfo);
+  }
+
+  if (activeInfo.count >= max) {
+    return {
+      success: false,
+      limit: max,
+      remaining: 0,
+      resetTime: activeInfo.resetTime,
+    };
+  }
+
+  activeInfo.count += 1;
+
+  return {
+    success: true,
+    limit: max,
+    remaining: max - activeInfo.count,
+    resetTime: activeInfo.resetTime,
+  };
+};
+
+/**
+ * Creates a limiter function. When Redis is available, counters are stored in
+ * Redis so they persist across processes and deployments. Otherwise we fall
+ * back to an in-memory store.
+ */
+export function rateLimit(options: RateLimitOptions) {
+  const { max, windowMs, keyGenerator } = options;
+  const redisClient = getRedisClient();
+
+  return async (request: Request): Promise<RateLimitResult> => {
+    const key = keyGenerator ? keyGenerator(request) : getClientIP(request);
+
+    if (redisClient) {
+      try {
+        return await redisRateLimit(redisClient, key, max, windowMs);
+      } catch (error) {
+        console.warn('[rate-limit] Redis error, falling back to in-memory:', error);
+      }
+    }
+
+    return inMemoryRateLimit(key, max, windowMs);
+  };
 }
 
 /**
- * Predefined rate limiters
+ * Pre-configured limiters used across the app.
  */
 export const rateLimiters = {
-  // Contact form: 5 requests per 15 minutes
   contactForm: rateLimit({
     max: 5,
     windowMs: 15 * 60 * 1000, // 15 minutes
   }),
-
-  // API general: 100 requests per hour
   apiGeneral: rateLimit({
     max: 100,
     windowMs: 60 * 60 * 1000, // 1 hour
   }),
-
-  // Search: 50 requests per 10 minutes
   search: rateLimit({
     max: 50,
     windowMs: 10 * 60 * 1000, // 10 minutes
   }),
 };
 
-export { rateLimitStore };
+export { getClientIP, inMemoryRateLimit, rateLimitStore };
 export default rateLimit;


### PR DESCRIPTION
## Summary
- refactor rate limiter utility to persist counters in Redis with key expirations and fall back to in-memory storage
- add coverage for Redis-backed and fallback rate limiter behavior

## Testing
- pnpm test:unit -- src/utils/__tests__/rate-limit.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f424564e48323b866a8065288e896)