### PR TITLE
chore: strengthen model test typing

### DIFF
--- a/app-next-directory/src/models/__tests__/NewsletterSubscriber.test.ts
+++ b/app-next-directory/src/models/__tests__/NewsletterSubscriber.test.ts
@@ -1,9 +1,28 @@
 import { jest } from '@jest/globals';
+import type {
+  CallbackWithoutResultAndOptionalError,
+  HydratedDocument,
+  Model,
+  Schema,
+  UpdateQuery,
+} from 'mongoose';
+import type { INewsletterSubscriber } from '../NewsletterSubscriber';
 
 const loadModel = async () => {
   const mod = await import('../NewsletterSubscriber');
   return mod.default;
 };
+
+type SchemaWithPreHooks = Schema<INewsletterSubscriber> & {
+  preHooks: Map<string, Array<(this: unknown, next?: CallbackWithoutResultAndOptionalError) => void>>;
+};
+
+type UpdateHookContext = { getUpdate: () => UpdateQuery<INewsletterSubscriber> };
+type UpdateHook = (this: UpdateHookContext, next?: CallbackWithoutResultAndOptionalError) => void;
+type ValidateHook = (
+  this: HydratedDocument<INewsletterSubscriber> & { createdAt?: Date; updatedAt?: Date },
+  next: CallbackWithoutResultAndOptionalError
+) => void;
 
 describe('NewsletterSubscriber model', () => {
   beforeEach(() => {
@@ -14,8 +33,8 @@ describe('NewsletterSubscriber model', () => {
   it('exposes the expected schema definition and defaults', async () => {
     const NewsletterSubscriber = await loadModel();
 
-    const emailPath = NewsletterSubscriber.schema.path('email') as any;
-    const confirmedAtPath = NewsletterSubscriber.schema.path('confirmedAt') as any;
+    const emailPath = NewsletterSubscriber.schema.path('email');
+    const confirmedAtPath = NewsletterSubscriber.schema.path('confirmedAt');
 
     expect(emailPath).toBeDefined();
     expect(emailPath.isRequired).toBe(true);
@@ -36,7 +55,7 @@ describe('NewsletterSubscriber model', () => {
 
   it('falls back to manual normalization when the schema setter is unavailable', async () => {
     const NewsletterSubscriber = await loadModel();
-    const schema = NewsletterSubscriber.schema as any;
+    const schema = NewsletterSubscriber.schema as SchemaWithPreHooks;
     const emailPath = schema.path('email');
     const originalSetter = emailPath.options.set;
 
@@ -69,13 +88,13 @@ describe('NewsletterSubscriber model', () => {
 
   it('normalises update payloads in the pre update hooks', async () => {
     const NewsletterSubscriber = await loadModel();
-    const schema = NewsletterSubscriber.schema as any;
+    const schema = NewsletterSubscriber.schema as SchemaWithPreHooks;
     const hooks = schema.preHooks.get('findOneAndUpdate');
     expect(hooks).toBeDefined();
-    const hook = hooks?.[0] as (this: { getUpdate: () => any }, next: () => void) => void;
+    const hook = hooks?.[0] as UpdateHook | undefined;
 
     const update = { email: '  UPDATED@Example.COM  ' };
-    const context = { getUpdate: () => update };
+    const context: UpdateHookContext = { getUpdate: () => update };
     const next = jest.fn();
 
     hook.call(context, next);
@@ -86,32 +105,26 @@ describe('NewsletterSubscriber model', () => {
 
   it('skips normalization when update payload does not include email', async () => {
     const NewsletterSubscriber = await loadModel();
-    const schema = NewsletterSubscriber.schema as any;
-    const hook = schema.preHooks.get('updateOne')?.[0] as (
-      this: { getUpdate: () => any },
-      next: () => void
-    ) => void;
+    const schema = NewsletterSubscriber.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('updateOne')?.[0] as UpdateHook | undefined;
 
     const update = { $set: { confirmedAt: new Date() } };
-    const context = { getUpdate: () => update };
-    hook.call(context);
+    const context: UpdateHookContext = { getUpdate: () => update };
+    hook?.call(context);
 
     expect(update.$set.confirmedAt).toBeInstanceOf(Date);
   });
 
   it('normalizes email values nested inside $set payloads', async () => {
     const NewsletterSubscriber = await loadModel();
-    const schema = NewsletterSubscriber.schema as any;
-    const hook = schema.preHooks.get('updateOne')?.[0] as (
-      this: { getUpdate: () => any },
-      next: () => void
-    ) => void;
+    const schema = NewsletterSubscriber.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('updateOne')?.[0] as UpdateHook | undefined;
 
     const update = { $set: { email: '  nested@example.COM  ' } };
-    const context = { getUpdate: () => update };
+    const context: UpdateHookContext = { getUpdate: () => update };
     const next = jest.fn();
 
-    hook.call(context, next);
+    hook?.call(context, next);
 
     expect(update.$set.email).toBe('nested@example.com');
     expect(next).toHaveBeenCalledTimes(1);
@@ -120,10 +133,10 @@ describe('NewsletterSubscriber model', () => {
   it('recompiles the model when an incomplete cached model exists', async () => {
     jest.resetModules();
     const imported = await import('mongoose');
-    const mongooseMod = (imported as any).default ?? imported;
+    const mongooseMod = imported.default ?? imported;
 
     const incomplete = mongooseMod.model('NewsletterSubscriber');
-    expect((incomplete as any).schema).toBeUndefined();
+    expect(incomplete.schema).toBeUndefined();
 
     const { default: compiled } = await import('../NewsletterSubscriber');
 
@@ -134,12 +147,12 @@ describe('NewsletterSubscriber model', () => {
   it('reuses an existing compiled model from the mongoose cache', async () => {
     jest.resetModules();
     const imported = await import('mongoose');
-    const mongooseMod = (imported as any).default ?? imported;
+    const mongooseMod = imported.default ?? imported;
     const cachedModel = Object.assign(jest.fn(), {
       schema: {},
       modelName: 'NewsletterSubscriber',
-    });
-    mongooseMod.models = { NewsletterSubscriber: cachedModel } as any;
+    }) as unknown as Model<INewsletterSubscriber>;
+    mongooseMod.models.NewsletterSubscriber = cachedModel;
 
     const { default: reused } = await import('../NewsletterSubscriber');
 
@@ -148,13 +161,13 @@ describe('NewsletterSubscriber model', () => {
 
   it('handles validation hook invocation when fields are absent', async () => {
     const NewsletterSubscriber = await loadModel();
-    const schema = NewsletterSubscriber.schema as any;
-    const hook = schema.preHooks.get('validate')?.[0] as (this: any, next: () => void) => void;
+    const schema = NewsletterSubscriber.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('validate')?.[0] as ValidateHook | undefined;
 
-    const doc: any = { isNew: true };
+    const doc: Partial<HydratedDocument<INewsletterSubscriber>> & { isNew: boolean } = { isNew: true };
     const next = jest.fn();
 
-    hook.call(doc, next);
+    hook?.call(doc as HydratedDocument<INewsletterSubscriber>, next);
 
     expect(doc.confirmedAt).toBeNull();
     expect(doc.createdAt).toBeInstanceOf(Date);

--- a/app-next-directory/src/models/__tests__/PasswordResetToken.test.ts
+++ b/app-next-directory/src/models/__tests__/PasswordResetToken.test.ts
@@ -1,10 +1,25 @@
 import { jest } from '@jest/globals';
-import mongoose from 'mongoose';
+import mongoose, {
+  type CallbackWithoutResultAndOptionalError,
+  type HydratedDocument,
+  type Model,
+  type Schema,
+} from 'mongoose';
+import type { IPasswordResetToken } from '../PasswordResetToken';
 
 const loadModel = async () => {
   const mod = await import('../PasswordResetToken');
   return mod.default;
 };
+
+type SchemaWithPreHooks = Schema<IPasswordResetToken> & {
+  preHooks: Map<string, Array<(this: unknown, next: CallbackWithoutResultAndOptionalError) => void>>;
+};
+
+type SaveHook = (
+  this: HydratedDocument<IPasswordResetToken> & { createdAt?: unknown },
+  next: CallbackWithoutResultAndOptionalError
+) => void;
 
 describe('PasswordResetToken model', () => {
   beforeEach(() => {
@@ -15,7 +30,7 @@ describe('PasswordResetToken model', () => {
   it('describes required schema fields and validators', async () => {
     const PasswordResetToken = await loadModel();
     const userIdPath = PasswordResetToken.schema.path('userId');
-    const tokenHashPath = PasswordResetToken.schema.path('tokenHash') as any;
+    const tokenHashPath = PasswordResetToken.schema.path('tokenHash');
     const expiresAtPath = PasswordResetToken.schema.path('expiresAt');
 
     expect(userIdPath?.isRequired).toBe(true);
@@ -32,7 +47,7 @@ describe('PasswordResetToken model', () => {
 
   it('registers all expected indexes', async () => {
     const PasswordResetToken = await loadModel();
-    const indexes = (PasswordResetToken.schema as any).indexes();
+    const indexes = PasswordResetToken.schema.indexes();
 
     expect(indexes).toEqual(
       expect.arrayContaining([
@@ -60,10 +75,10 @@ describe('PasswordResetToken model', () => {
 
   it('coerces createdAt values to Date inside the save hook', async () => {
     const PasswordResetToken = await loadModel();
-    const schema = PasswordResetToken.schema as any;
-    const hook = schema.preHooks.get('save')?.[0] as (this: any, next: () => void) => void;
+    const schema = PasswordResetToken.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('save')?.[0] as SaveHook | undefined;
 
-    const doc: any = new PasswordResetToken({
+    const doc = new PasswordResetToken({
       userId: new mongoose.Types.ObjectId(),
       tokenHash: 'b'.repeat(64),
       expiresAt: new Date(Date.now() + 2000),
@@ -72,7 +87,7 @@ describe('PasswordResetToken model', () => {
     doc.createdAt = '2024-01-01T00:00:00.000Z';
 
     const next = jest.fn();
-    hook.call(doc, next);
+    hook?.call(doc, next);
 
     expect(doc.createdAt).toBeInstanceOf(Date);
     expect(doc.createdAt.toISOString()).toBe('2024-01-01T00:00:00.000Z');
@@ -81,11 +96,11 @@ describe('PasswordResetToken model', () => {
 
   it('keeps Date instances intact within the save hook', async () => {
     const PasswordResetToken = await loadModel();
-    const schema = PasswordResetToken.schema as any;
-    const hook = schema.preHooks.get('save')?.[0] as (this: any, next: () => void) => void;
+    const schema = PasswordResetToken.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('save')?.[0] as SaveHook | undefined;
 
     const initialDate = new Date('2023-12-31T23:59:59.000Z');
-    const doc: any = new PasswordResetToken({
+    const doc = new PasswordResetToken({
       userId: new mongoose.Types.ObjectId(),
       tokenHash: 'c'.repeat(64),
       expiresAt: new Date(Date.now() + 3000),
@@ -93,7 +108,7 @@ describe('PasswordResetToken model', () => {
     });
 
     const next = jest.fn();
-    hook.call(doc, next);
+    hook?.call(doc, next);
 
     expect(doc.createdAt).toBe(initialDate);
     expect(next).toHaveBeenCalledTimes(1);
@@ -102,12 +117,12 @@ describe('PasswordResetToken model', () => {
   it('reuses an existing compiled model from the mongoose cache', async () => {
     jest.resetModules();
     const imported = await import('mongoose');
-    const mongooseMod = (imported as any).default ?? imported;
+    const mongooseMod = imported.default ?? imported;
     const cachedModel = Object.assign(jest.fn(), {
       schema: {},
       modelName: 'PasswordResetToken',
-    });
-    mongooseMod.models = { PasswordResetToken: cachedModel } as any;
+    }) as unknown as Model<IPasswordResetToken>;
+    mongooseMod.models.PasswordResetToken = cachedModel;
 
     const { default: reused } = await import('../PasswordResetToken');
     expect(reused).toBe(cachedModel);

--- a/app-next-directory/src/models/__tests__/User.test.ts
+++ b/app-next-directory/src/models/__tests__/User.test.ts
@@ -1,4 +1,11 @@
 import { jest } from '@jest/globals';
+import type {
+  CallbackWithoutResultAndOptionalError,
+  HydratedDocument,
+  Model,
+  Schema,
+} from 'mongoose';
+import type { IUser } from '../User';
 
 const mockHash = jest.fn().mockResolvedValue('$2a$12$hashed');
 
@@ -10,6 +17,15 @@ const loadModule = async () => {
   const mod = await import('../User');
   return mod;
 };
+
+type SchemaWithPreHooks = Schema<IUser> & {
+  preHooks: Map<string, Array<(this: unknown, next: CallbackWithoutResultAndOptionalError) => Promise<void>>>;
+};
+
+type SaveHook = (
+  this: HydratedDocument<IUser> & { isModified: (field: string) => boolean },
+  next: CallbackWithoutResultAndOptionalError
+) => Promise<void>;
 
 describe('User model', () => {
   beforeEach(() => {
@@ -34,9 +50,9 @@ describe('User model', () => {
   it('declares schema fields with appropriate defaults and validators', async () => {
     const { default: User, ROLE_VALUES } = await loadModule();
 
-    const emailPath = User.schema.path('email') as any;
-    const rolePath = User.schema.path('role') as any;
-    const passwordPath = User.schema.path('password') as any;
+    const emailPath = User.schema.path('email');
+    const rolePath = User.schema.path('role');
+    const passwordPath = User.schema.path('password');
 
     expect(emailPath.isRequired).toBeDefined();
     expect(emailPath.options.trim).toBe(true);
@@ -67,20 +83,20 @@ describe('User model', () => {
     expect(doc.updatedAt).toBeInstanceOf(Date);
   });
 
-  const invokeSaveHook = async (doc: any, next = jest.fn()) => {
+  const invokeSaveHook = async (
+    doc: HydratedDocument<IUser> & { isModified: (field: string) => boolean },
+    next = jest.fn()
+  ) => {
     const { default: User } = await loadModule();
-    const schema = User.schema as any;
-    const hook = schema.preHooks.get('save')?.[0] as (
-      this: any,
-      next: (err?: unknown) => void
-    ) => Promise<void>;
-    await hook.call(doc, next);
+    const schema = User.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('save')?.[0] as SaveHook | undefined;
+    await hook?.call(doc, next);
     return next;
   };
 
   it('hashes passwords when the field is modified', async () => {
     const { default: User, BCRYPT_COST } = await loadModule();
-    const doc: any = new User({ email: 'user@example.com', password: 'password123' });
+    const doc = new User({ email: 'user@example.com', password: 'password123' });
     doc.isModified = jest.fn().mockReturnValue(true);
 
     const next = await invokeSaveHook(doc);
@@ -92,7 +108,7 @@ describe('User model', () => {
 
   it('skips hashing when the password has not been modified', async () => {
     const { default: User } = await loadModule();
-    const doc: any = new User({ email: 'user@example.com', password: 'unchanged' });
+    const doc = new User({ email: 'user@example.com', password: 'unchanged' });
     doc.isModified = jest.fn().mockReturnValue(false);
 
     const next = await invokeSaveHook(doc);
@@ -104,7 +120,7 @@ describe('User model', () => {
 
   it('skips hashing when the password is undefined even if marked modified', async () => {
     const { default: User } = await loadModule();
-    const doc: any = new User({ email: 'user@example.com' });
+    const doc = new User({ email: 'user@example.com' });
     doc.isModified = jest.fn().mockReturnValue(true);
 
     const next = await invokeSaveHook(doc);
@@ -115,7 +131,7 @@ describe('User model', () => {
 
   it('does not rehash passwords that are already bcrypt hashes', async () => {
     const { default: User } = await loadModule();
-    const doc: any = new User({ email: 'user@example.com', password: '$2a$12$existingHash' });
+    const doc = new User({ email: 'user@example.com', password: '$2a$12$existingHash' });
     doc.isModified = jest.fn().mockReturnValue(true);
 
     const next = await invokeSaveHook(doc);
@@ -127,18 +143,15 @@ describe('User model', () => {
 
   it('propagates hashing errors through the save hook', async () => {
     const { default: User } = await loadModule();
-    const doc: any = new User({ email: 'user@example.com', password: 'password123' });
+    const doc = new User({ email: 'user@example.com', password: 'password123' });
     doc.isModified = jest.fn().mockReturnValue(true);
 
     mockHash.mockImplementationOnce(() => Promise.reject(new Error('hash failure')));
 
     const next = jest.fn();
-    const schema = User.schema as any;
-    const hook = schema.preHooks.get('save')?.[0] as (
-      this: any,
-      next: (err?: unknown) => void
-    ) => Promise<void>;
-    await hook.call(doc, next);
+    const schema = User.schema as SchemaWithPreHooks;
+    const hook = schema.preHooks.get('save')?.[0] as SaveHook | undefined;
+    await hook?.call(doc, next);
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
@@ -148,12 +161,12 @@ describe('User model', () => {
   it('reuses a cached compiled model when available', async () => {
     jest.resetModules();
     const imported = await import('mongoose');
-    const mongooseMod = (imported as any).default ?? imported;
+    const mongooseMod = imported.default ?? imported;
     const cachedModel = Object.assign(jest.fn(), {
       schema: {},
       modelName: 'User',
-    });
-    mongooseMod.models = { User: cachedModel } as any;
+    }) as unknown as Model<IUser>;
+    mongooseMod.models.User = cachedModel;
 
     const { default: reused } = await import('../User');
     expect(reused).toBe(cachedModel);


### PR DESCRIPTION
## Summary
- add explicit mongoose typings to newsletter subscriber tests in place of `any` casts
- tighten password reset token test hooks and cached model typings
- refine user model tests to exercise hooks without explicit `any` annotations

## Testing
- pnpm lint (emits existing warnings elsewhere)
- pnpm lint:next (fails: script not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402a00db408323b560416d56ca937d)