### PR TITLE
Fix type safety in analytics and auth tests

### DIFF
--- a/app-next-directory/src/lib/analytics/__tests__/analytics-manager.test.ts
+++ b/app-next-directory/src/lib/analytics/__tests__/analytics-manager.test.ts
@@ -35,8 +35,8 @@ describe('AnalyticsManager', () => {
     const analyticsModule = await import('../analytics');
     const { analytics } = analyticsModule;
 
-    const again = (analytics.constructor as any).getInstance();
-    expect(again).toBe(analytics);
+    const { analytics: analyticsAgain } = await import('../analytics');
+    expect(analyticsAgain).toBe(analytics);
 
     analytics.trackExperiment(
       {
@@ -103,13 +103,19 @@ describe('AnalyticsManager', () => {
 
     await analytics.initialize();
 
-    const [, options] = mockPosthog.init.mock.calls[0];
+    const [, options] = mockPosthog.init.mock.calls[0] as [
+      string,
+      {
+        api_host?: string;
+        loaded?: (posthog: { debug: () => void }) => void;
+      },
+    ];
     expect(options).toMatchObject({
       api_host: 'https://app.posthog.com',
       loaded: expect.any(Function),
     });
 
-    options.loaded?.({ debug: mockPosthog.debug } as any);
+    options.loaded?.({ debug: mockPosthog.debug });
     expect(mockPosthog.debug).toHaveBeenCalled();
 
     process.env.NODE_ENV = originalNodeEnv;

--- a/app-next-directory/src/lib/analytics/__tests__/config.test.ts
+++ b/app-next-directory/src/lib/analytics/__tests__/config.test.ts
@@ -55,10 +55,10 @@ describe('analytics config helpers', () => {
     process.env.NEXT_PUBLIC_POSTHOG_TOKEN = 'token';
     process.env.NODE_ENV = 'production';
 
-    let trackPageView: any;
-    let trackEvent: any;
-    let identifyUser: any;
-    let ANALYTICS_CONFIG: any;
+    let trackPageView: typeof import('../config').trackPageView;
+    let trackEvent: typeof import('../config').trackEvent;
+    let identifyUser: typeof import('../config').identifyUser;
+    let ANALYTICS_CONFIG: typeof import('../config').ANALYTICS_CONFIG;
 
     jest.isolateModules(() => {
       const mod = require('../config');
@@ -100,9 +100,9 @@ describe('analytics config helpers', () => {
     analyticsInstance.track.mockRejectedValueOnce(new Error('track-error'));
     analyticsInstance.identify.mockRejectedValueOnce(new Error('identify-error'));
 
-    let trackPageView: any;
-    let trackEvent: any;
-    let identifyUser: any;
+    let trackPageView: typeof import('../config').trackPageView;
+    let trackEvent: typeof import('../config').trackEvent;
+    let identifyUser: typeof import('../config').identifyUser;
 
     const loggerErrorSpy = jest.spyOn(jest.requireMock('@/lib/logger').structuredLogger, 'error');
 

--- a/app-next-directory/src/lib/auth/adapter.test.ts
+++ b/app-next-directory/src/lib/auth/adapter.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import type { Adapter } from 'next-auth/adapters';
 
 jest.mock('@auth/mongodb-adapter', () => ({
   MongoDBAdapter: jest.fn(),
@@ -49,8 +50,8 @@ describe('createAuthAdapter', () => {
   it('returns MongoDB adapter when USE_REAL_MONGODB_FOR_TESTS is set', async () => {
     process.env.MONGODB_URI = 'mongodb://example.com';
     process.env.USE_REAL_MONGODB_FOR_TESTS = '1';
-    const adapterInstance = { connected: true };
-    mockMongoDBAdapter.mockReturnValue(adapterInstance as any);
+    const adapterInstance = { connected: true } as unknown as Adapter;
+    mockMongoDBAdapter.mockReturnValue(adapterInstance);
 
     const { createAuthAdapter } = require('./adapter');
     const adapter = createAuthAdapter();

--- a/app-next-directory/src/lib/auth/clientAuth.test.tsx
+++ b/app-next-directory/src/lib/auth/clientAuth.test.tsx
@@ -22,6 +22,8 @@ jest.mock('next-auth/react', () => ({
 const useSessionMock = useSession as jest.Mock;
 const signInMock = signIn as jest.Mock;
 const signOutMock = signOut as jest.Mock;
+type PagePermissionChecker = typeof import('../../types/auth').hasPagePermission;
+type FeaturePermissionChecker = typeof import('../../types/auth').hasFeaturePermission;
 
 describe('clientAuth context and helpers', () => {
   beforeEach(() => {
@@ -47,8 +49,10 @@ describe('clientAuth context and helpers', () => {
       status: 'authenticated',
     });
 
-    const hasPagePermissionMock = jest.fn(() => true);
-    const hasFeaturePermissionMock = jest.fn(() => false);
+    const hasPagePermissionMock: jest.MockedFunction<PagePermissionChecker> = jest.fn(() => true);
+    const hasFeaturePermissionMock: jest.MockedFunction<FeaturePermissionChecker> = jest.fn(
+      () => false
+    );
 
     const Consumer = () => {
       const ctx = useAuthContext();
@@ -74,10 +78,7 @@ describe('clientAuth context and helpers', () => {
 
     const user = userEvent.setup();
     render(
-      <AuthProvider
-        hasPagePermission={hasPagePermissionMock as any}
-        hasFeaturePermission={hasFeaturePermissionMock as any}
-      >
+      <AuthProvider hasPagePermission={hasPagePermissionMock} hasFeaturePermission={hasFeaturePermissionMock}>
         <Consumer />
       </AuthProvider>
     );
@@ -218,10 +219,12 @@ describe('clientAuth context and helpers', () => {
         status: 'authenticated',
       });
 
-      const hasFeaturePermissionMock = jest.fn(() => true);
+      const hasFeaturePermissionMock: jest.MockedFunction<FeaturePermissionChecker> = jest.fn(
+        () => true
+      );
 
       render(
-        <AuthProvider hasFeaturePermission={hasFeaturePermissionMock as any}>
+        <AuthProvider hasFeaturePermission={hasFeaturePermissionMock}>
           <RequirePermission feature="editContent">
             <div data-testid="permission-pass">Granted</div>
           </RequirePermission>
@@ -238,10 +241,12 @@ describe('clientAuth context and helpers', () => {
         status: 'authenticated',
       });
 
-      const hasFeaturePermissionMock = jest.fn(() => false);
+      const hasFeaturePermissionMock: jest.MockedFunction<FeaturePermissionChecker> = jest.fn(
+        () => false
+      );
 
       render(
-        <AuthProvider hasFeaturePermission={hasFeaturePermissionMock as any}>
+        <AuthProvider hasFeaturePermission={hasFeaturePermissionMock}>
           <RequirePermission
             feature="editContent"
             fallback={<div data-testid="permission-fallback">No access</div>}

--- a/app-next-directory/src/lib/auth/serverAuth.test.ts
+++ b/app-next-directory/src/lib/auth/serverAuth.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import type { UserRole } from '@/types/auth';
 
 // Mock dependencies
 const mockBcryptCompare = jest.fn();
@@ -444,7 +445,7 @@ describe('serverAuth', () => {
       mockIsValidObjectId.mockReturnValue(false);
 
       const { updateUserRole } = await import('./serverAuth');
-      const result = await updateUserRole('invalid-id', 'admin' as any);
+      const result = await updateUserRole('invalid-id', 'admin' as UserRole);
 
       expect(result).toBe(false);
       expect(mockUserModel.updateOne).not.toHaveBeenCalled();
@@ -455,7 +456,7 @@ describe('serverAuth', () => {
       mockUserModel.updateOne.mockResolvedValue({ matchedCount: 1 });
 
       const { updateUserRole } = await import('./serverAuth');
-      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as any);
+      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as UserRole);
 
       expect(result).toBe(true);
       expect(mockUserModel.updateOne).toHaveBeenCalledWith(
@@ -470,7 +471,7 @@ describe('serverAuth', () => {
       mockUserModel.updateOne.mockResolvedValue({ matchedCount: 0 });
 
       const { updateUserRole } = await import('./serverAuth');
-      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as any);
+      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as UserRole);
 
       expect(result).toBe(false);
     });
@@ -480,7 +481,7 @@ describe('serverAuth', () => {
       mockUserModel.updateOne.mockRejectedValue(new Error('Database error'));
 
       const { updateUserRole } = await import('./serverAuth');
-      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as any);
+      const result = await updateUserRole('507f1f77bcf86cd799439011', 'admin' as UserRole);
 
       expect(result).toBe(false);
     });


### PR DESCRIPTION
## Summary
- update analytics tests to avoid `any` usage and use typed PostHog init expectations
- tighten analytics config test helper types
- adjust auth tests to use typed mocks and roles instead of `any`

## Testing
- pnpm lint:next *(passes with existing repository warnings about unrelated `any` usages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694044f64bfc83239bb392f645048b08)