### PR TITLE
test: tighten sanity mocks

### DIFF
--- a/app-next-directory/src/lib/__tests__/sanity-batch-processor.test.ts
+++ b/app-next-directory/src/lib/__tests__/sanity-batch-processor.test.ts
@@ -108,7 +108,7 @@ describe('SanityBatchProcessor', () => {
       .mockRejectedValueOnce(new Error('temporary'))
       .mockResolvedValueOnce({ _id: 'listing-1' });
 
-    (processor as any).retryDelay = 0;
+    (processor as unknown as { retryDelay: number }).retryDelay = 0;
 
     const result = await processor.createListingsBatch([listing], { concurrency: 1 });
 
@@ -187,11 +187,11 @@ describe('SanityBatchProcessor', () => {
       { listing: { ...baseListing, country: '' }, message: 'Country is required' },
       { listing: { ...baseListing, website: 'not-a-url' }, message: 'Invalid website URL' },
       {
-        listing: { ...baseListing, coordinates: { lat: 200, lng: 0 } as any },
+        listing: { ...baseListing, coordinates: { lat: 200, lng: 0 } },
         message: 'Invalid latitude',
       },
       {
-        listing: { ...baseListing, coordinates: { lat: 0, lng: -200 } as any },
+        listing: { ...baseListing, coordinates: { lat: 0, lng: -200 } },
         message: 'Invalid longitude',
       },
       {
@@ -199,13 +199,20 @@ describe('SanityBatchProcessor', () => {
         message: 'Eco tags must be an array with max 10 items',
       },
       {
-        listing: { ...baseListing, images: new Array(21).fill({}) as any },
+        listing: {
+          ...baseListing,
+          images: Array.from({ length: 21 }, () =>
+            new File([new Uint8Array([1])], 'extra.jpg', { type: 'image/jpeg' })
+          ),
+        },
         message: 'Maximum 20 images allowed per listing',
       },
     ];
 
     for (const { listing, message } of cases) {
-      expect(() => (processor as any).validateSingleListing(listing)).toThrow(message);
+      expect(() =>
+        (processor as unknown as { validateSingleListing(l: Partial<Listing>): void }).validateSingleListing(listing)
+      ).toThrow(message);
     }
   });
 });

--- a/app-next-directory/src/lib/__tests__/sanity-http-client.test.ts
+++ b/app-next-directory/src/lib/__tests__/sanity-http-client.test.ts
@@ -11,29 +11,63 @@ const REQUIRED_ENV = {
   SANITY_API_TOKEN: 'test-api-token',
 };
 
-const mockCreateClient = jest.fn((config: { token?: string }) =>
-  mockCreateClient.mock.calls.length === 0 || !config.token ? mockReadClient : mockWriteClient
-) as jest.Mock<any>;
-const mockCommit = jest.fn() as jest.Mock<any>;
-const mockSet = jest.fn(() => ({ commit: mockCommit })) as jest.Mock<any>;
-const mockPatch = jest.fn(() => ({ set: mockSet })) as jest.Mock<any>;
-const mockTransactionCreate = jest.fn() as jest.Mock<any>;
-const mockTransactionCommit = jest.fn() as jest.Mock<any>;
+type SanityDocument = Record<string, unknown> & {
+  _id?: string;
+  _type?: string;
+  error?: unknown;
+  statusCode?: number;
+};
+
+const mockCommit = jest.fn<Promise<SanityDocument | null | undefined>, []>();
+const mockSet = jest.fn(() => ({ commit: mockCommit }));
+const mockPatch = jest.fn(() => ({ set: mockSet }));
+const mockTransactionCreate = jest.fn<Promise<SanityDocument | undefined>, [SanityDocument]>();
+const mockTransactionCommit = jest.fn<Promise<SanityDocument | { results?: Array<{ document?: SanityDocument }> } | undefined>, []>();
 const mockTransaction = jest.fn(() => ({
   create: mockTransactionCreate,
   commit: mockTransactionCommit,
-})) as jest.Mock<any>;
-const mockReadClient = {
-  fetch: jest.fn() as jest.Mock<any>,
-  withConfig: jest.fn() as jest.Mock<any>,
+}));
+type SanityReadClient = {
+  fetch: jest.Mock<Promise<unknown>, [string, unknown?]>;
+  withConfig: jest.Mock<SanityReadClient, [Record<string, unknown>]>;
 };
-const mockWriteClient = {
-  create: jest.fn() as jest.Mock<any>,
-  delete: jest.fn() as jest.Mock<any>,
-  assets: { upload: jest.fn() as jest.Mock<any> },
-  patch: mockPatch,
-  transaction: mockTransaction,
+
+type SanityWriteClient = {
+  create: jest.Mock<Promise<SanityDocument | undefined>, [Record<string, unknown>]>;
+  delete: jest.Mock<Promise<SanityDocument | undefined>, [string]>;
+  assets: {
+    upload: jest.Mock<
+      Promise<SanityDocument | null | undefined>,
+      [Buffer | ArrayBuffer, { filename?: string; contentType?: string; title?: string; description?: string }?]
+    >;
+  };
+  patch: jest.Mock<{ set: typeof mockSet }, [string]>;
+  transaction: jest.Mock<
+    { create: typeof mockTransactionCreate; commit: typeof mockTransactionCommit },
+    []
+  >;
 };
+
+type ClientFactory = (config: { token?: string }) => SanityReadClient | SanityWriteClient;
+const mockReadClient: SanityReadClient = {
+  fetch: jest.fn<Promise<unknown>, [string, unknown?]>(),
+  withConfig: jest.fn<SanityReadClient, [Record<string, unknown>]>(),
+};
+const mockWriteClient: SanityWriteClient = {
+  create: jest.fn<Promise<SanityDocument | undefined>, [Record<string, unknown>]>(),
+  delete: jest.fn<Promise<SanityDocument | undefined>, [string]>(),
+  assets: {
+    upload: jest.fn<
+      Promise<SanityDocument | null | undefined>,
+      [Buffer | ArrayBuffer, { filename?: string; contentType?: string; title?: string; description?: string }?]
+    >(),
+  },
+  patch: mockPatch as jest.Mock<{ set: typeof mockSet }, [string]>,
+  transaction: mockTransaction as jest.Mock<{ create: typeof mockTransactionCreate; commit: typeof mockTransactionCommit }, []>,
+};
+const mockCreateClient = jest.fn<ClientFactory>((config: { token?: string }) =>
+  mockCreateClient.mock.calls.length === 0 || !config.token ? mockReadClient : mockWriteClient
+);
 
 jest.mock('../sanity/client', () => ({
   createClient: mockCreateClient,
@@ -112,7 +146,9 @@ describe('SanityHTTPClient', () => {
       jest.doMock('@/lib/logger');
       const mod = await import('../sanity-http-client');
       new mod.SanityHTTPClient();
-      const logger = jest.mocked((jest.requireMock('@/lib/logger') as any).structuredLogger);
+      const logger = jest.mocked(
+        (jest.requireMock('@/lib/logger') as { structuredLogger: typeof structuredLogger }).structuredLogger
+      );
       expect(logger.warn).toHaveBeenCalledWith(
         'Missing optional environment variable: SANITY_API_TOKEN',
         {
@@ -272,7 +308,9 @@ describe('SanityHTTPClient', () => {
 
         expect(mockWriteClient.create).toHaveBeenCalledWith({ _type: 'test' });
         expect(result).toEqual(doc);
-        const logger = jest.mocked((jest.requireMock('@/lib/logger') as any).structuredLogger);
+        const logger = jest.mocked(
+          (jest.requireMock('@/lib/logger') as { structuredLogger: typeof structuredLogger }).structuredLogger
+        );
         expect(logger.info).toHaveBeenCalledWith('Sanity document created', {
           component: 'sanity-http',
           id: 'doc-1',
@@ -294,7 +332,9 @@ describe('SanityHTTPClient', () => {
         const result = await client.create({ _type: 'test' });
 
         expect(result).toEqual({ _type: 'test', title: 'no-id' });
-        const logger = jest.mocked((jest.requireMock('@/lib/logger') as any).structuredLogger);
+        const logger = jest.mocked(
+          (jest.requireMock('@/lib/logger') as { structuredLogger: typeof structuredLogger }).structuredLogger
+        );
         expect(logger.info).toHaveBeenCalledWith('Sanity document created (no _id)', {
           component: 'sanity-http',
         });
@@ -363,7 +403,9 @@ describe('SanityHTTPClient', () => {
 
         await client.update('doc-2', { title: 'debug' });
 
-        const logger = jest.mocked((jest.requireMock('@/lib/logger') as any).structuredLogger);
+        const logger = jest.mocked(
+          (jest.requireMock('@/lib/logger') as { structuredLogger: typeof structuredLogger }).structuredLogger
+        );
         expect(logger.info).toHaveBeenCalledWith('Sanity document updated', {
           component: 'sanity-http',
           id: 'doc-2',
@@ -448,11 +490,13 @@ describe('SanityHTTPClient', () => {
         jest.doMock('@/lib/logger');
         const mod = await import('../sanity-http-client');
         const client = new mod.SanityHTTPClient();
-        mockWriteClient.delete.mockResolvedValue({ success: true } as any);
+        mockWriteClient.delete.mockResolvedValue({ success: true });
 
         await client.delete('doc-3');
 
-        const logger = jest.mocked((jest.requireMock('@/lib/logger') as any).structuredLogger);
+        const logger = jest.mocked(
+          (jest.requireMock('@/lib/logger') as { structuredLogger: typeof structuredLogger }).structuredLogger
+        );
         expect(logger.info).toHaveBeenCalledWith('Sanity document deleted', {
           component: 'sanity-http',
           id: 'doc-3',

--- a/app-next-directory/src/lib/__tests__/sanity-image-uploader.test.ts
+++ b/app-next-directory/src/lib/__tests__/sanity-image-uploader.test.ts
@@ -33,7 +33,8 @@ describe('SanityImageUploader', () => {
 
   beforeAll(() => {
     if (typeof btoa === 'undefined') {
-      (global as any).btoa = (input: string) => Buffer.from(input, 'binary').toString('base64');
+      (globalThis as { btoa?: (input: string) => string }).btoa = (input: string) =>
+        Buffer.from(input, 'binary').toString('base64');
     }
   });
 
@@ -52,7 +53,7 @@ describe('SanityImageUploader', () => {
     URL.createObjectURL = jest.fn(() => 'blob:mock');
     URL.revokeObjectURL = jest.fn();
 
-    originalImage = (global as any).Image;
+    originalImage = (globalThis as { Image?: typeof Image }).Image as typeof Image;
 
     class MockImage {
       public onload: () => void = () => {};
@@ -64,7 +65,7 @@ describe('SanityImageUploader', () => {
       }
     }
 
-    (global as any).Image = MockImage as unknown as typeof Image;
+    (globalThis as { Image?: typeof Image }).Image = MockImage as unknown as typeof Image;
 
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -75,14 +76,14 @@ describe('SanityImageUploader', () => {
     if (originalURLCreate) {
       URL.createObjectURL = originalURLCreate;
     } else {
-      delete (URL as any).createObjectURL;
+      delete (URL as Record<string, unknown>).createObjectURL;
     }
     if (originalURLRevoke) {
       URL.revokeObjectURL = originalURLRevoke;
     } else {
-      delete (URL as any).revokeObjectURL;
+      delete (URL as Record<string, unknown>).revokeObjectURL;
     }
-    (global as any).Image = originalImage;
+    (globalThis as { Image?: typeof Image }).Image = originalImage;
     jest.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- replace explicit `any` usage in sanity HTTP client, batch processor, and image uploader tests with typed mocks and helpers
- adjust test fixtures to avoid `any` casts while preserving invalid data scenarios

## Testing
- pnpm lint:next *(fails: script not found in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940452c24188323ba9169bb4da7a9f0)