### PR TITLE
chore: replace any in rate limiter tests

### DIFF
--- a/app-next-directory/src/lib/__tests__/mongodb.test.ts
+++ b/app-next-directory/src/lib/__tests__/mongodb.test.ts
@@ -21,11 +21,14 @@ jest.mock('@/lib/logger', () => ({
 
 describe('mongodb client module', () => {
   const originalEnv = process.env;
+  const globalWithMongo = global as typeof globalThis & {
+    _mongoClientPromise?: Promise<unknown>;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
-    delete (global as any)._mongoClientPromise;
+    delete globalWithMongo._mongoClientPromise;
     mockConnect.mockReset();
     mockMongoClient.mockClear();
     mockMongoClient.mockImplementation(() => ({ connect: mockConnect }));
@@ -33,7 +36,7 @@ describe('mongodb client module', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
-    delete (global as any)._mongoClientPromise;
+    delete globalWithMongo._mongoClientPromise;
   });
 
   afterAll(() => {
@@ -107,7 +110,7 @@ describe('mongodb client module', () => {
 
     expect(mockMongoClient).toHaveBeenCalledTimes(1);
     expect(mockConnect).toHaveBeenCalledTimes(1);
-    expect((global as any)._mongoClientPromise).toBeDefined();
+    expect(globalWithMongo._mongoClientPromise).toBeDefined();
   });
   it('logs and rethrows connection errors outside of development caching', async () => {
     jest.resetModules();
@@ -143,7 +146,7 @@ describe('mongodb client module', () => {
       component: 'mongodb',
       message: 'dev-fail',
     });
-    expect((global as any)._mongoClientPromise).toBeUndefined();
+    expect(globalWithMongo._mongoClientPromise).toBeUndefined();
   });
 
   it('returns a connected client in production when credentials are valid', async () => {
@@ -167,7 +170,7 @@ describe('mongodb client module', () => {
   it('reuses an existing cached promise in development without reconnecting', async () => {
     jest.resetModules();
     const cached = Promise.resolve({ cached: true });
-    (global as any)._mongoClientPromise = cached;
+    globalWithMongo._mongoClientPromise = cached;
 
     process.env.NODE_ENV = 'development';
     process.env.MONGODB_URI = 'mongodb://localhost:27017/test';

--- a/app-next-directory/src/lib/__tests__/rate-limit.test.ts
+++ b/app-next-directory/src/lib/__tests__/rate-limit.test.ts
@@ -223,38 +223,40 @@ describe('rate-limit helpers', () => {
   });
 
   it('wraps exports with jest.fn when Jest is available', async () => {
-    const originalJest = (global as any).jest;
+    const globalWithOptionalJest = global as typeof globalThis & { jest?: Pick<typeof jest, 'fn'> };
+    const originalJest = globalWithOptionalJest.jest;
 
     try {
       const mod = await loadModule(() => {
-        (global as any).jest = { fn: jest.fn.bind(jest) };
+        globalWithOptionalJest.jest = { fn: jest.fn.bind(jest) };
       });
       const { getClientIp, isRateLimited, getRetryAfterMs } = mod;
 
-      expect(typeof (getClientIp as any).mock).toBe('object');
-      expect(typeof (isRateLimited as any).mock).toBe('object');
-      expect(typeof (getRetryAfterMs as any).mock).toBe('object');
+      expect(jest.isMockFunction(getClientIp)).toBe(true);
+      expect(jest.isMockFunction(isRateLimited)).toBe(true);
+      expect(jest.isMockFunction(getRetryAfterMs)).toBe(true);
     } finally {
-      (global as any).jest = originalJest;
+      globalWithOptionalJest.jest = originalJest;
     }
   });
 
   it('falls back to original functions when Jest is unavailable', async () => {
-    const originalJest = (global as any).jest;
+    const globalWithOptionalJest = global as typeof globalThis & { jest?: Pick<typeof jest, 'fn'> };
+    const originalJest = globalWithOptionalJest.jest;
 
     try {
       const mod = await loadModule(() => {
-        delete (global as any).jest;
+        delete globalWithOptionalJest.jest;
       });
 
-      expect('mock' in (mod.getClientIp as any)).toBe(false);
-      expect('mock' in (mod.isRateLimited as any)).toBe(false);
-      expect('mock' in (mod.getRetryAfterMs as any)).toBe(false);
+      expect(jest.isMockFunction(mod.getClientIp)).toBe(false);
+      expect(jest.isMockFunction(mod.isRateLimited)).toBe(false);
+      expect(jest.isMockFunction(mod.getRetryAfterMs)).toBe(false);
       expect(warnSpy).toHaveBeenCalledWith('Jest not available for mocking in rate-limit module', {
         component: 'rate-limit',
       });
     } finally {
-      (global as any).jest = originalJest;
+      globalWithOptionalJest.jest = originalJest;
     }
   });
 

--- a/app-next-directory/src/lib/__tests__/redis.test.ts
+++ b/app-next-directory/src/lib/__tests__/redis.test.ts
@@ -163,7 +163,10 @@ describe('redis module', () => {
   });
 });
 
-const redisConstructor = jest.fn(function Redis(this: any, config: Record<string, unknown>) {
+const redisConstructor = jest.fn(function Redis(
+  this: { config?: Record<string, unknown> },
+  config: Record<string, unknown>
+) {
   Object.assign(this, { config });
 });
 
@@ -200,7 +203,7 @@ describe('redis helpers', () => {
   it('allows manually setting and retrieving the redis client', async () => {
     const { setRedisClient, getRedisClient } = await import('../redis');
 
-    const client = { kind: 'manual-client' } as any;
+    const client = { kind: 'manual-client' } as unknown as Redis;
     setRedisClient(client);
 
     expect(getRedisClient()).toBe(client);
@@ -214,20 +217,20 @@ describe('redis helpers', () => {
 
     expect(listener).toHaveBeenCalledWith(undefined);
 
-    const firstClient = { id: 1 } as any;
+    const firstClient = { id: 1 } as unknown as Redis;
     setRedisClient(firstClient);
     expect(listener).toHaveBeenCalledWith(firstClient);
 
     unsubscribe();
 
-    setRedisClient({ id: 2 } as any);
+    setRedisClient({ id: 2 } as unknown as Redis);
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it('supports jest-style helpers on getRedisClient in tests', async () => {
     const { getRedisClient } = await import('../redis');
 
-    const mockClient = { id: 'mocked' } as any;
+    const mockClient = { id: 'mocked' } as unknown as Redis;
     getRedisClient.mockReturnValue(mockClient);
     expect(getRedisClient()).toBe(mockClient);
 
@@ -260,7 +263,7 @@ describe('redis helpers', () => {
       }
     });
 
-    setRedisClient({ id: 3 } as any);
+    setRedisClient({ id: 3 } as unknown as Redis);
 
     const mockLogger = jest.requireMock<typeof import('@/lib/logger')>('@/lib/logger');
     expect(mockLogger.structuredLogger.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- replace usage of `any` in mongodb, rate-limit, and redis test suites with typed helpers
- ensure global references are typed to satisfy lint rules

## Testing
- pnpm lint:next

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694045a34da88323a4d86d3517379434)