### PR TITLE
Fix any usage in Next.js page tests

### DIFF
--- a/app-next-directory/app/listings/[slug]/__tests__/page.test.tsx
+++ b/app-next-directory/app/listings/[slug]/__tests__/page.test.tsx
@@ -48,11 +48,23 @@ jest.mock('@/components/layout/Footer', () => ({
 const originalFetch = global.fetch;
 const originalStructuredClone = global.structuredClone;
 
+type GlobalWithStructuredClone = typeof globalThis & {
+  structuredClone?: typeof structuredClone;
+};
+
+const setStructuredClone = (implementation: typeof structuredClone) => {
+  (global as GlobalWithStructuredClone).structuredClone = implementation;
+};
+
+const clearStructuredClone = () => {
+  delete (global as GlobalWithStructuredClone).structuredClone;
+};
+
 const structuredClonePolyfill = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
 
 beforeAll(() => {
   if (typeof global.structuredClone !== 'function') {
-    (global as any).structuredClone = structuredClonePolyfill as typeof structuredClone;
+    setStructuredClone(structuredClonePolyfill as typeof structuredClone);
   }
 });
 
@@ -67,7 +79,7 @@ describe('app/listings/[slug]/page', () => {
     mockGetCollection.mockReset();
     global.fetch = jest.fn() as unknown as typeof fetch;
     if (typeof global.structuredClone !== 'function') {
-      (global as any).structuredClone = structuredClonePolyfill as typeof structuredClone;
+      setStructuredClone(structuredClonePolyfill as typeof structuredClone);
     }
   });
 
@@ -79,9 +91,9 @@ describe('app/listings/[slug]/page', () => {
   afterAll(() => {
     global.fetch = originalFetch;
     if (originalStructuredClone) {
-      (global as any).structuredClone = originalStructuredClone;
+      setStructuredClone(originalStructuredClone);
     } else {
-      delete (global as any).structuredClone;
+      clearStructuredClone();
     }
   });
 

--- a/app-next-directory/app/newsletter/confirmed/__tests__/page.test.tsx
+++ b/app-next-directory/app/newsletter/confirmed/__tests__/page.test.tsx
@@ -30,13 +30,17 @@ jest.mock('@/components/ui/neo-card', () => ({
 
 jest.mock('@/components/ui/neo-button', () => ({
   __esModule: true,
-  NeoButton: ({ children, asChild, ...props }: any) =>
-    asChild ? <span {...props}>{children}</span> : <button {...props}>{children}</button>,
+  NeoButton: ({ children, asChild, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  }) => (asChild ? <span {...props}>{children}</span> : <button {...props}>{children}</button>),
 }));
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 let NewsletterConfirmedPage: React.ComponentType;

--- a/app-next-directory/app/search/page.test.tsx
+++ b/app-next-directory/app/search/page.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import type React from 'react';
 import type { SearchParamRecord } from '@/types/search';
 
 const headerRenderMock = jest.fn(() => <header data-testid="header" />);
@@ -41,8 +42,10 @@ jest.mock('@/components/listings/ListingGrid', () => ({
 }));
 
 jest.mock('@/components/ui/neo-button', () => ({
-  NeoButton: ({ children, asChild = false, ...rest }: any) =>
-    asChild ? children : <button {...rest}>{children}</button>,
+  NeoButton: ({ children, asChild = false, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  }) => (asChild ? children : <button {...rest}>{children}</button>),
 }));
 
 jest.mock('./results/server', () => ({

--- a/app-next-directory/app/search/results/page.test.tsx
+++ b/app-next-directory/app/search/results/page.test.tsx
@@ -2,35 +2,45 @@
 
 import '@testing-library/jest-dom';
 import { render, screen, within } from '@testing-library/react';
+import type React from 'react';
+
+type ListingGridProps = { listings: unknown[] };
+type SearchFiltersProps = { initialParams: Record<string, unknown> };
 
 import { extractTagNames, mapResultToDTO } from './helpers';
 
-const listingGridRenderMock = jest.fn(({ listings }: any) => (
+const listingGridRenderMock = jest.fn(({ listings }: ListingGridProps) => (
   <div data-testid="listing-grid">{JSON.stringify(listings)}</div>
 ));
-const searchFiltersRenderMock = jest.fn(({ initialParams }: any) => (
+const searchFiltersRenderMock = jest.fn(({ initialParams }: SearchFiltersProps) => (
   <div data-testid="search-filters-form">{JSON.stringify(initialParams)}</div>
 ));
 
 const fetchSearchResultsMock = jest.fn();
 
 jest.mock('@/components/ui/neo-button', () => ({
-  NeoButton: ({ children, asChild = false, ...props }: any) =>
-    asChild ? children : <button {...props}>{children}</button>,
+  NeoButton: ({ children, asChild = false, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  }) => (asChild ? children : <button {...props}>{children}</button>),
 }));
 
 jest.mock('@/components/listings/ListingGrid', () => ({
-  ListingGrid: (props: any) => listingGridRenderMock(props),
+  ListingGrid: (props: ListingGridProps) => listingGridRenderMock(props),
 }));
 
 jest.mock('@/components/search/SearchFiltersForm', () => ({
-  SearchFiltersForm: (props: any) => searchFiltersRenderMock(props),
+  SearchFiltersForm: (props: SearchFiltersProps) => searchFiltersRenderMock(props),
 }));
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ href, children, ...props }: any) => (
-    <a href={typeof href === 'string' ? href : (href?.pathname ?? '')} {...props}>
+  default: ({
+    href,
+    children,
+    ...props
+  }: { href: string | URL; children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={typeof href === 'string' ? href : href.pathname} {...props}>
       {children}
     </a>
   ),
@@ -177,7 +187,7 @@ describe('Search results page module', () => {
       tags: ['wifi', 'vegan'],
       page: '2',
       limit: '24',
-    } as Record<string, any>);
+    } as Record<string, string | string[]>);
 
     const ui = await ResultsPage({ searchParams });
     render(ui);


### PR DESCRIPTION
## Summary
- replace explicit any casts in listings page tests with typed structuredClone helpers
- tighten props typing in newsletter confirmation and search page component mocks
- add explicit prop types for search results mocks and search param fixtures

## Testing
- pnpm lint:next

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404591f6c48323b27f0f0f49301e39)