### PR TITLE
Fix lint warnings in performance and sanity tests

### DIFF
--- a/app-next-directory/src/lib/performance/__tests__/web-vitals-reporter.test.fixed.ts
+++ b/app-next-directory/src/lib/performance/__tests__/web-vitals-reporter.test.fixed.ts
@@ -1,8 +1,8 @@
-import { WebVitalsReporter } from '../web-vitals-reporter';
+import { WebVitalsReporter, type WebVitalsMetric } from '../web-vitals-reporter';
 
 describe('WebVitalsReporter (fixed)', () => {
-  const originalNavigator = (global as any).navigator;
-  const originalFetch = (global as any).fetch;
+  const originalNavigator = globalThis.navigator;
+  const originalFetch = globalThis.fetch;
 
   afterEach(() => {
     Object.defineProperty(global, 'navigator', {
@@ -17,7 +17,7 @@ describe('WebVitalsReporter (fixed)', () => {
   });
 
   test('uses navigator.sendBeacon when available and returns true', () => {
-    const sendBeacon = jest.fn(() => true);
+    const sendBeacon = jest.fn<(url: string, data?: BodyInit | null) => boolean>(() => true);
     Object.defineProperty(global, 'navigator', {
       configurable: true,
       value: { sendBeacon },
@@ -27,18 +27,18 @@ describe('WebVitalsReporter (fixed)', () => {
       value: jest.fn(() => Promise.resolve({ ok: true })),
     });
 
-    const metric = { id: '1', name: 'CLS', value: 1 } as any;
+    const metric = { id: '1', name: 'CLS', value: 1 } satisfies WebVitalsMetric;
     WebVitalsReporter(metric);
 
     expect(sendBeacon).toHaveBeenCalledWith(
       '/api/performance/web-vitals',
       JSON.stringify({ ...metric, entries: [] })
     );
-    expect((global as any).fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test('falls back to fetch when sendBeacon exists but returns false', () => {
-    const sendBeacon = jest.fn(() => false);
+    const sendBeacon = jest.fn<(url: string, data?: BodyInit | null) => boolean>(() => false);
     Object.defineProperty(global, 'navigator', {
       configurable: true,
       value: { sendBeacon },
@@ -49,7 +49,7 @@ describe('WebVitalsReporter (fixed)', () => {
       value: fetchMock,
     });
 
-    const metric = { id: '2', name: 'LCP', value: 2 } as any;
+    const metric = { id: '2', name: 'LCP', value: 2 } satisfies WebVitalsMetric;
     WebVitalsReporter(metric);
 
     expect(sendBeacon).toHaveBeenCalled();

--- a/app-next-directory/src/lib/performance/__tests__/web-vitals-reporter.test.ts
+++ b/app-next-directory/src/lib/performance/__tests__/web-vitals-reporter.test.ts
@@ -350,7 +350,7 @@ describe('recordMetric', () => {
       value: fetchMock,
     });
 
-    const circular: any = {};
+    const circular: Record<string, unknown> & { self?: unknown } = {};
     circular.self = circular;
 
     expect(() => recordMetric('circular', 99, circular)).not.toThrow();

--- a/app-next-directory/src/lib/sanity/image.test.ts
+++ b/app-next-directory/src/lib/sanity/image.test.ts
@@ -1,3 +1,4 @@
+import type { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { builder } from './client';
 import { urlFor } from './image';
 
@@ -30,19 +31,19 @@ describe('urlFor', () => {
   });
 
   test('should return undefined for a null source', () => {
-    const imageUrl = urlFor({} as any);
+    const imageUrl = urlFor(null as unknown as SanityImageSource);
     expect(imageUrl).toBeUndefined();
     expect(builder.image).not.toHaveBeenCalled();
   });
 
   test('should return undefined for an undefined source', () => {
-    const imageUrl = urlFor({} as any);
+    const imageUrl = urlFor(undefined as unknown as SanityImageSource);
     expect(imageUrl).toBeUndefined();
     expect(builder.image).not.toHaveBeenCalled();
   });
 
   test('should return undefined for an empty object source', () => {
-    const imageUrl = urlFor({});
+    const imageUrl = urlFor({} as unknown as SanityImageSource);
     expect(imageUrl).toBeUndefined();
     expect(builder.image).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- replace `any` casts in web vitals reporter tests with typed mocks and metrics
- type the circular detail object in web vitals recordMetric test without using `any`
- cast null, undefined, and empty sources to `SanityImageSource` in the Sanity image tests

## Testing
- pnpm exec eslint --max-warnings=0 src/lib/performance/__tests__/web-vitals-reporter.test.fixed.ts src/lib/performance/__tests__/web-vitals-reporter.test.ts src/lib/sanity/image.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fdf5de54832395572affe0575498)