### PR TITLE
fix: remove explicit any usage in tests

### DIFF
--- a/app-next-directory/src/lib/http/__tests__/request-json-helpers.test.ts
+++ b/app-next-directory/src/lib/http/__tests__/request-json-helpers.test.ts
@@ -187,7 +187,7 @@ describe('request JSON helpers', () => {
     it('should preserve method when merging options', () => {
       const body = { test: 'data' };
       const result = jsonPostOptions(body, {
-        method: 'PUT' as any, // This should be overridden
+        method: 'PUT' as RequestInit['method'], // This should be overridden
       });
 
       expect(result.method).toBe('POST'); // POST should take precedence

--- a/app-next-directory/src/lib/image-utils/getImageDimensions.test.ts
+++ b/app-next-directory/src/lib/image-utils/getImageDimensions.test.ts
@@ -12,7 +12,7 @@ describe('getImageDimensions', () => {
           dimensions: { width: 800, height: 600 },
         },
       },
-    } as any;
+    } satisfies Parameters<typeof getImageDimensions>[0];
 
     const dims = getImageDimensions(image);
     expect(dims.width).toBe(800);
@@ -21,7 +21,9 @@ describe('getImageDimensions', () => {
   });
 
   it('returns empty when metadata is missing', () => {
-    const image = { asset: { url: 'http://example.com/img.jpg' } } as any;
+    const image = { asset: { url: 'http://example.com/img.jpg' } } satisfies Parameters<
+      typeof getImageDimensions
+    >[0];
     expect(getImageDimensions(image)).toEqual({});
   });
 });

--- a/app-next-directory/src/lib/performance/__tests__/baseline-testing.test.ts
+++ b/app-next-directory/src/lib/performance/__tests__/baseline-testing.test.ts
@@ -31,7 +31,7 @@ describe('baseline-testing utilities', () => {
 
   it('generates a lighthouse config mapped to performance budgets', () => {
     const config = generateLighthouseConfig();
-    const budget = (config.budgets as any[])[0];
+    const budget = config.budgets?.[0];
 
     expect(config.settings?.onlyCategories).toContain('performance');
     expect(budget.resourceSizes).toEqual(

--- a/app-next-directory/src/lib/performance/__tests__/collector.test.ts
+++ b/app-next-directory/src/lib/performance/__tests__/collector.test.ts
@@ -87,7 +87,7 @@ describe('performance collector', () => {
       plausible,
       performance: { mark, measure } as Record<string, unknown>,
       PerformanceObserver: MockPerformanceObserver as unknown,
-    } as unknown as Record<string, any>;
+    } as Record<string, unknown>;
     dependencies.global = dependencies.window;
 
     dependencies.getNodeEnv = () => 'development';
@@ -150,7 +150,7 @@ describe('performance collector', () => {
 
     dependencies.window = { performance: { mark, measure } as Record<string, unknown> } as Record<
       string,
-      any
+      unknown
     >;
     dependencies.global = dependencies.window;
 
@@ -198,7 +198,7 @@ describe('performance collector', () => {
       performance: { mark, measure },
       PerformanceObserver: GlobalObserver as unknown,
       plausible,
-    } as Record<string, any>;
+    } as Record<string, unknown>;
 
     dependencies.getNodeEnv = () => 'production';
     initPerformanceMonitoring();
@@ -236,8 +236,8 @@ describe('performance collector', () => {
       callbacks.CLS = cb;
     });
 
-    dependencies.window = { plausible: 'not-a-function' } as Record<string, any>;
-    dependencies.global = {} as Record<string, any>;
+    dependencies.window = { plausible: 'not-a-function' } as Record<string, unknown>;
+    dependencies.global = {} as Record<string, unknown>;
 
     dependencies.getNodeEnv = () => 'production';
     const consoleLogSpy = jest.spyOn(console, 'log');
@@ -257,8 +257,8 @@ describe('performance collector', () => {
       callbacks.CLS = cb;
     });
 
-    dependencies.window = {} as Record<string, any>;
-    dependencies.global = {} as Record<string, any>;
+    dependencies.window = {} as Record<string, unknown>;
+    dependencies.global = {} as Record<string, unknown>;
 
     dependencies.getNodeEnv = () => 'test';
     initPerformanceMonitoring();

--- a/app-next-directory/src/lib/performance/__tests__/plausible.test.ts
+++ b/app-next-directory/src/lib/performance/__tests__/plausible.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe('plausible-integration', () => {
   let mockPlausible: jest.Mock;
-  let originalWindow: (Window & typeof globalThis & { plausible?: any }) | undefined;
+  let originalWindow: (Window & typeof globalThis & { plausible?: unknown }) | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -24,7 +24,7 @@ describe('plausible-integration', () => {
     originalWindow = dependencies.window;
     dependencies.window = {
       plausible: mockPlausible,
-    } as any;
+    } as const;
   });
 
   afterEach(() => {
@@ -43,7 +43,7 @@ describe('plausible-integration', () => {
 
     it('should be immutable', () => {
       expect(() => {
-        (PERFORMANCE_EVENTS as any).WEB_VITALS = 'modified';
+        (PERFORMANCE_EVENTS as Record<string, string>).WEB_VITALS = 'modified';
       }).toThrow();
     });
   });
@@ -62,7 +62,7 @@ describe('plausible-integration', () => {
     });
 
     it('should warn if plausible is not initialized', () => {
-      dependencies.window = {} as any;
+      dependencies.window = {} as Record<string, never>;
 
       reportPerformanceEvent({
         name: 'CLS',
@@ -338,7 +338,7 @@ describe('plausible-integration', () => {
     });
 
     it('should work when plausible is not initialized', () => {
-      dependencies.window = {} as any;
+      dependencies.window = {} as Record<string, never>;
       const { trackPerformance } = usePerformanceTracking();
 
       expect(() => {


### PR DESCRIPTION
## Summary
- replace explicit `any` casts in HTTP, image, and performance tests with typed alternatives
- tighten window and configuration casts to use concrete record types instead of `any`
- simplify lighthouse budget assertion without loosening types

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fe1e6738832393e9827a109b0b2c)