### PR TITLE
Fix auth test typings and remove unused type alias

### DIFF
--- a/app-next-directory/src/components/sections/__tests__/CategoryFilters.test.tsx
+++ b/app-next-directory/src/components/sections/__tests__/CategoryFilters.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
 import { CategoryFilters } from '../CategoryFilters';
 
 jest.mock('lucide-react', () => ({
@@ -52,6 +53,7 @@ describe('CategoryFilters', () => {
   it('supports custom item lists supplied by parents', () => {
     const CustomHarness = () => {
       const [value, setValue] = useState<string[]>([]);
+      const CustomIcon: LucideIcon = () => <span data-testid="custom-icon" />;
       return (
         <CategoryFilters
           value={value}
@@ -61,7 +63,7 @@ describe('CategoryFilters', () => {
               id: 'custom',
               name: 'Custom',
               count: 1,
-              icon: (() => <span data-testid="custom-icon" />) as any,
+              icon: CustomIcon,
             },
           ]}
         />

--- a/app-next-directory/src/components/sections/__tests__/CityCarousel.test.tsx
+++ b/app-next-directory/src/components/sections/__tests__/CityCarousel.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import type { EmblaCarouselType } from 'embla-carousel';
 import useEmblaCarousel from 'embla-carousel-react';
 import { HttpResponse, http } from 'msw';
 import { server } from '../../../test-helpers/msw-server-bridge';
@@ -11,7 +12,12 @@ jest.mock('embla-carousel-autoplay', () => ({
   default: jest.fn(() => ({ stop: jest.fn(), play: jest.fn() })),
 }));
 
-const emblaApiMock = {
+type EmblaApiSubset = Pick<
+  EmblaCarouselType,
+  'scrollPrev' | 'scrollNext' | 'canScrollPrev' | 'canScrollNext' | 'on' | 'off'
+>;
+
+const emblaApiMock: jest.Mocked<EmblaApiSubset> = {
   scrollPrev: jest.fn(),
   scrollNext: jest.fn(),
   canScrollPrev: jest.fn(() => true),
@@ -32,7 +38,7 @@ describe('CityCarousel', () => {
     jest.clearAllMocks();
     emblaApiMock.canScrollPrev.mockReturnValue(true);
     emblaApiMock.canScrollNext.mockReturnValue(true);
-    mockedUseEmblaCarousel.mockReturnValue([jest.fn(), emblaApiMock as any]);
+    mockedUseEmblaCarousel.mockReturnValue([jest.fn(), emblaApiMock as unknown as EmblaCarouselType]);
 
     server.use(http.get('/api/cities', () => HttpResponse.json({ cities: mockCities })));
   });

--- a/app-next-directory/src/lib/auth/serverAuth.ts
+++ b/app-next-directory/src/lib/auth/serverAuth.ts
@@ -28,11 +28,6 @@ type UserDoc = {
   emailVerified?: Date | null;
   favorites?: Array<Types.ObjectId | string>;
 };
-// Narrowed fields used when authenticating a user
-type SelectedAuthDoc = Pick<
-  UserDoc,
-  '_id' | 'name' | 'email' | 'image' | 'role' | 'password' | 'emailVerified'
->;
 const UserModel = User as unknown as import('mongoose').Model<UserDoc>;
 export interface AuthenticatedUser {
   id: string;

--- a/app-next-directory/src/lib/auth/withAuthMatrix.test.ts
+++ b/app-next-directory/src/lib/auth/withAuthMatrix.test.ts
@@ -5,6 +5,7 @@ import { getToken } from 'next-auth/jwt';
 jest.mock('@/lib/logger');
 
 import { structuredLogger } from '@/lib/logger';
+import { ACCESS_CONTROL_MATRIX, type PagePermissions, type UserRole } from '../../types/auth';
 
 type StructuredLogger = typeof import('@/lib/logger')['structuredLogger'];
 
@@ -27,6 +28,19 @@ const mockGetToken = getToken as jest.MockedFunction<typeof getToken>;
 const mockAuth = jest.fn();
 const mockHasPagePermission = jest.fn();
 const mockHasFeaturePermission = jest.fn();
+
+type PageKey = keyof (typeof ACCESS_CONTROL_MATRIX)[UserRole]['pages'];
+type PageAction = keyof PagePermissions;
+type FeatureKey = keyof (typeof ACCESS_CONTROL_MATRIX)[UserRole]['features'];
+
+const adminPage: PageKey = 'admin';
+const homePage: PageKey = 'home';
+const editListingPage: PageKey = 'editListing';
+const viewAction: PageAction = 'canView';
+const editAction: PageAction = 'canEdit';
+const manageListingsFeature: FeatureKey = 'editAllListings';
+const manageUsersFeature: FeatureKey = 'manageUserRoles';
+const editOwnListingsFeature: FeatureKey = 'editOwnListings';
 
 jest.mock('@/lib/auth', () => ({
   __esModule: true,
@@ -105,8 +119,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/api/test');
       const response = await withAuthMatrix(
         request,
-        'adminPanel' as any,
-        'canView' as any,
+        adminPage,
+        viewAction,
         true,
         undefined,
         mockHasPagePermission
@@ -126,8 +140,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/api/test');
       const response = await withAuthMatrix(
         request,
-        'adminPanel' as any,
-        'canView' as any,
+        adminPage,
+        viewAction,
         true,
         undefined,
         mockHasPagePermission
@@ -146,8 +160,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/');
       const response = await withAuthMatrix(
         request,
-        'home' as any,
-        'canView' as any,
+        homePage,
+        viewAction,
         false,
         undefined,
         mockHasPagePermission
@@ -164,8 +178,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/admin');
       const response = await withAuthMatrix(
         request,
-        'adminPanel' as any,
-        'canView' as any,
+        adminPage,
+        viewAction,
         false,
         undefined,
         mockHasPagePermission
@@ -184,8 +198,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/admin');
       const response = await withAuthMatrix(
         request,
-        'adminPanel' as any,
-        'canView' as any,
+        adminPage,
+        viewAction,
         false,
         undefined,
         mockHasPagePermission
@@ -203,8 +217,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/admin');
       const response = await withAuthMatrix(
         request,
-        'adminPanel' as any,
-        'canView' as any,
+        adminPage,
+        viewAction,
         false,
         undefined,
         mockHasPagePermission
@@ -223,8 +237,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/listings/edit/123');
       const response = await withAuthMatrix(
         request,
-        'editListing' as any,
-        'canEdit' as any,
+        editListingPage,
+        editAction,
         false,
         { userId: 'user123', resourceOwnerId: 'user123' },
         mockHasPagePermission
@@ -245,8 +259,8 @@ describe('withAuthMatrix', () => {
       const request = new NextRequest('http://localhost:3000/listings/edit/456');
       const response = await withAuthMatrix(
         request,
-        'editListing' as any,
-        'canEdit' as any,
+        editListingPage,
+        editAction,
         false,
         { userId: 'user123', resourceOwnerId: 'user456' },
         mockHasPagePermission
@@ -309,7 +323,7 @@ describe('withAuthApiFeature', () => {
     const request = new NextRequest('http://localhost:3000/api/feature');
     const response = await withAuthApiFeature(
       request,
-      'manageListings' as any,
+      manageListingsFeature,
       undefined,
       mockHasFeaturePermission
     );
@@ -326,7 +340,7 @@ describe('withAuthApiFeature', () => {
     const request = new NextRequest('http://localhost:3000/api/feature');
     const response = await withAuthApiFeature(
       request,
-      'manageUsers' as any,
+      manageUsersFeature,
       undefined,
       mockHasFeaturePermission
     );
@@ -343,7 +357,7 @@ describe('withAuthApiFeature', () => {
     const request = new NextRequest('http://localhost:3000/api/feature');
     const response = await withAuthApiFeature(
       request,
-      'manageUsers' as any,
+      manageUsersFeature,
       undefined,
       mockHasFeaturePermission
     );
@@ -359,7 +373,7 @@ describe('withAuthApiFeature', () => {
     const request = new NextRequest('http://localhost:3000/api/listings/123');
     const response = await withAuthApiFeature(
       request,
-      'editOwnListings' as any,
+      editOwnListingsFeature,
       { userId: 'user123', resourceOwnerId: 'user123' },
       mockHasFeaturePermission
     );
@@ -375,7 +389,7 @@ describe('withAuthApiFeature', () => {
     const request = new NextRequest('http://localhost:3000/api/listings/456');
     const response = await withAuthApiFeature(
       request,
-      'editOwnListings' as any,
+      editOwnListingsFeature,
       { userId: 'user123', resourceOwnerId: 'user456' },
       mockHasFeaturePermission
     );
@@ -395,7 +409,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue(null);
 
       const request = new NextRequest('http://localhost:3000/api/admin');
-      const response = await withMinimumRole(request, 'admin' as any, true);
+      const response = await withMinimumRole(request, 'admin', true);
 
       expect(response.status).toBe(401);
     });
@@ -404,7 +418,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue({ role: 'user' });
 
       const request = new NextRequest('http://localhost:3000/api/admin');
-      const response = await withMinimumRole(request, 'admin' as any, true);
+      const response = await withMinimumRole(request, 'admin', true);
 
       expect(response.status).toBe(403);
       const json = await response.json();
@@ -415,7 +429,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue({ role: 'admin' });
 
       const request = new NextRequest('http://localhost:3000/api/admin');
-      const response = await withMinimumRole(request, 'moderator' as any, true);
+      const response = await withMinimumRole(request, 'venueOwner', true);
 
       expect(response).toBeInstanceOf(NextResponse);
       expect(response.status).not.toBe(403);
@@ -427,7 +441,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue(null);
 
       const request = new NextRequest('http://localhost:3000/admin');
-      const response = await withMinimumRole(request, 'admin' as any, false);
+      const response = await withMinimumRole(request, 'admin', false);
 
       expect(response.status).toBe(307);
       const location = response.headers.get('location');
@@ -438,7 +452,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue(null);
 
       const request = new NextRequest('http://localhost:3000/');
-      const response = await withMinimumRole(request, 'unidentifiedUser' as any, false);
+      const response = await withMinimumRole(request, 'user', false);
 
       expect(response).toBeInstanceOf(NextResponse);
       expect(response.status).not.toBe(307);
@@ -448,7 +462,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue({ role: 'user' });
 
       const request = new NextRequest('http://localhost:3000/admin');
-      const response = await withMinimumRole(request, 'admin' as any, false);
+      const response = await withMinimumRole(request, 'admin', false);
 
       expect(response.status).toBe(307);
       const location = response.headers.get('location');
@@ -459,7 +473,7 @@ describe('withMinimumRole', () => {
       mockGetToken.mockResolvedValue({ role: 'admin' });
 
       const request = new NextRequest('http://localhost:3000/admin');
-      const response = await withMinimumRole(request, 'user' as any, false);
+      const response = await withMinimumRole(request, 'user', false);
 
       expect(response).toBeInstanceOf(NextResponse);
       expect(response.status).not.toBe(307);


### PR DESCRIPTION
## Summary
- type custom icons and Embla mocks without using `any`
- align auth middleware tests with access-control types and valid role values
- remove unused SelectedAuthDoc alias from serverAuth

## Testing
- pnpm lint:next (reports unrelated existing warnings in other tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fe4dd4a8832382541daab894905c)