### PR TITLE
Fix mock handler test data typings

### DIFF
--- a/app-next-directory/src/mocks/handlers/api.ts
+++ b/app-next-directory/src/mocks/handlers/api.ts
@@ -28,14 +28,6 @@ const data = createTestData();
 const ok = <Body>(body: Body, status = 200) =>
   HttpResponse.json(body as Record<string, unknown>, { status });
 
-interface ListingItem {
-  _id: string;
-  name: string;
-  city: { name: string; slug?: { current: string } };
-  slug?: { current: string };
-  [key: string]: unknown;
-}
-
 /**
  * Internal API route handlers
  */
@@ -47,8 +39,8 @@ export const apiHandlers = [
     const url = new URL(request.url);
     const query = url.searchParams.get('q') ?? '';
     const results = data.listings
-      .filter((listing: ListingItem) => listing.name.toLowerCase().includes(query.toLowerCase()))
-      .map((listing: ListingItem) => ({
+      .filter(listing => listing.name.toLowerCase().includes(query.toLowerCase()))
+      .map(listing => ({
         id: listing._id,
         name: listing.name,
         city: listing.city.name,
@@ -80,8 +72,8 @@ export const apiHandlers = [
     }
     const query = typeof body?.query === 'string' ? body.query.trim().toLowerCase() : '';
     const results = data.listings
-      .filter((listing: ListingItem) => listing.name.toLowerCase().includes(query))
-      .map((listing: ListingItem) => ({
+      .filter(listing => listing.name.toLowerCase().includes(query))
+      .map(listing => ({
         id: listing._id,
         name: listing.name,
         city: listing.city.name,
@@ -113,9 +105,7 @@ export const apiHandlers = [
    * Categories API
    */
   http.get('/api/categories', () => {
-    const categories = Array.from(
-      new Set(data.listings.map((listing: ListingItem) => listing.type))
-    );
+    const categories = Array.from(new Set(data.listings.map(listing => listing.type)));
     return ok({ categories });
   }),
 
@@ -181,7 +171,7 @@ export const apiHandlers = [
     const url = new URL(request.url);
     const citySlug = url.searchParams.get('citySlug');
     const listings = citySlug
-      ? data.listings.filter((listing: ListingItem) => listing.city.slug?.current === citySlug)
+      ? data.listings.filter(listing => listing.city.slug?.current === citySlug)
       : data.listings;
 
     return ok({
@@ -275,8 +265,12 @@ export const apiHandlers = [
    */
   http.get('/api/user/favorites', () => {
     const user = data.users[0];
+    if (!user) {
+      return ok({ favorites: [] });
+    }
+
     const favorites = getFavoritesForUser(user.id).map(favorite => {
-      const listing = data.listings.find((item: ListingItem) => item._id === favorite.listingId);
+      const listing = data.listings.find(item => item._id === favorite.listingId);
       return {
         _id: favorite.id,
         createdAt: favorite.createdAt,

--- a/app-next-directory/src/mocks/handlers/sanity.ts
+++ b/app-next-directory/src/mocks/handlers/sanity.ts
@@ -143,7 +143,7 @@ export const sanityHandlers = [
         });
       }
 
-      const review = data.reviews?.find((r: { _id: string }) => r._id === docId);
+      const review = data.reviews?.find(({ id }) => id === docId);
       if (review) {
         return HttpResponse.json({
           documents: [review],

--- a/app-next-directory/src/types/tests-helpers.d.ts
+++ b/app-next-directory/src/types/tests-helpers.d.ts
@@ -1,7 +1,68 @@
 declare module '@/tests/helpers/test-data' {
-  export function createTestData(...args: unknown[]): unknown;
-  export function getFavoritesForUser(userId: string): unknown[];
-  export function getReviewsForListing(listingId: string): unknown[];
-  export function listCities(): unknown[];
-  export const defaultTestData: unknown;
+  import type { Role } from '@/models/User';
+  import type { AppReview } from '@/types/appView';
+  import type { EcoTag, Listing } from '@/types/listings';
+
+  export interface TestUser {
+    id: string;
+    name: string;
+    email: string;
+    role: Role;
+    plan: 'free' | 'premium';
+    password: string;
+    sessionToken: string;
+    image?: string;
+  }
+
+  export interface TestCity {
+    id: string;
+    name: string;
+    slug: string;
+    country: string;
+    description: string;
+    heroImage: string;
+    coordinates: {
+      lat: number;
+      lng: number;
+    };
+    sustainabilityScore: number;
+    highlights: string[];
+    listingIds: string[];
+  }
+
+  export interface TestFavorite {
+    id: string;
+    userId: string;
+    listingId: string;
+    createdAt: string;
+  }
+
+  export type TestEcoTag = EcoTag;
+
+  export interface TestData {
+    users: TestUser[];
+    listings: Listing[];
+    cities: TestCity[];
+    favorites: TestFavorite[];
+    reviews: AppReview[];
+    ecoTags: TestEcoTag[];
+  }
+
+  export interface TestSession {
+    token: string;
+    user: TestUser;
+  }
+
+  export const TEST_SESSION_COOKIE_NAME: string;
+  export const mockListings: Listing[];
+
+  export function createTestData(overrides?: Partial<TestData>): TestData;
+  export function getTestUser(role: Role): TestUser | undefined;
+  export function getSessionForRole(role: Role): TestSession | undefined;
+  export function getFavoritesForUser(userId: string): TestFavorite[];
+  export function getReviewsForListing(listingId: string): AppReview[];
+  export function getListingBySlug(slug: string): Listing | undefined;
+  export function listCities(): TestCity[];
+  export function listEcoTags(): TestEcoTag[];
+  export function pickTags(...slugs: string[]): EcoTag[];
 }


### PR DESCRIPTION
## Summary
- align test data module typings so mocks can consume strongly typed fixtures
- adjust MSW API and Sanity handlers to work with typed fixture data and guard missing favorites user

## Testing
- pnpm lint src/mocks/handlers/api.ts src/mocks/handlers/sanity.ts src/tests/fixtures/index.ts src/tests/fixtures/page.tsx
- pnpm check-types *(fails: existing project-wide TypeScript errors outside touched files)*
- pnpm test:unit *(fails: existing Jest ESM parsing issues in jest.setup.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a67848ac8323b6849e4b67f7556a)