### PR TITLE
fix(profile): remove redundant favorites section to prevent stacked 404 error

### DIFF
--- a/app-next-directory/app/__tests__/profile-page.test.tsx
+++ b/app-next-directory/app/__tests__/profile-page.test.tsx
@@ -1,10 +1,8 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type React from 'react';
 
 const mockUseSession = jest.fn();
-const favoriteShowcaseProps: Array<{ listings: any[]; onRemove: (id: string) => void }> = [];
-
 jest.mock('next-auth/react', () => ({
   useSession: (...args: unknown[]) => mockUseSession(...args),
 }));
@@ -71,27 +69,6 @@ jest.mock('@/components/profile/ProfileEditForm', () => ({
   ),
 }));
 
-jest.mock('../profile/FavoriteListingsShowcase', () => ({
-  FavoriteListingsShowcase: (props: { listings: any[]; onRemove: (id: string) => void }) => {
-    favoriteShowcaseProps.push(props);
-    return (
-      <div data-testid="favorite-showcase">
-        <span data-testid="favorites-count">{props.listings.length}</span>
-        {props.listings.map(listing => (
-          <button
-            key={listing.id}
-            type="button"
-            onClick={() => props.onRemove(listing.id)}
-            data-testid={`remove-${listing.id}`}
-          >
-            Remove {listing.id}
-          </button>
-        ))}
-      </div>
-    );
-  },
-}));
-
 const mockedNormaliseFavorite = jest.fn((entry: any) => {
   if (!entry) return null;
   const slug = entry?.listing?.slug;
@@ -151,7 +128,6 @@ afterAll(() => {
 
 afterEach(() => {
   mockUseSession.mockReset();
-  favoriteShowcaseProps.length = 0;
   global.fetch = originalFetch;
 });
 
@@ -183,99 +159,6 @@ describe('ProfilePage', () => {
     );
   });
 
-  it('loads and renders favorites for authenticated users', async () => {
-    mockUseSession.mockReturnValue({
-      data: {
-        user: {
-          id: 'user-1',
-          name: 'Jordan Doe',
-          email: 'jordan@example.com',
-          role: 'user',
-          image: 'https://example.com/avatar.jpg',
-        },
-      },
-      status: 'authenticated',
-      update: jest.fn(),
-    });
-
-    const favoritesResponse = {
-      favorites: [
-        {
-          _id: 'fav-1',
-          createdAt: '2024-03-01T00:00:00.000Z',
-          listing: {
-            slug: 'eco-stay',
-            name: 'Eco Stay',
-            city: { name: 'Eco City', country: 'Wonderland' },
-            priceRange: 'moderate',
-            ecoFocusTags: ['Solar'],
-            digitalNomadFeatures: ['Fast WiFi'],
-            primaryImage: {
-              asset: {
-                url: 'https://example.com/image.jpg',
-                metadata: { dimensions: { width: 800, height: 600 } },
-              },
-              altText: 'Eco stay image',
-            },
-          },
-        },
-      ],
-    };
-
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => favoritesResponse,
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({}),
-      } as Response);
-
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    const { default: ProfilePage } = await import('../profile/page');
-
-    render(<ProfilePage />);
-
-    const showcase = await screen.findByTestId('favorite-showcase');
-    expect(showcase).toBeInTheDocument();
-    expect(favoriteShowcaseProps.at(-1)?.listings.length).toBe(1);
-    expect(screen.getByTestId('favorites-count')).toHaveTextContent('1');
-    expect(fetchMock).toHaveBeenCalledWith('/api/user/favorites', expect.any(Object));
-
-    fireEvent.click(screen.getByTestId('remove-fav-1'));
-
-    await waitFor(() =>
-      expect(screen.getByText("You haven't saved any venues yet.")).toBeInTheDocument()
-    );
-    expect(fetchMock).toHaveBeenCalledWith('/api/user/favorites/fav-1', { method: 'DELETE' });
-  });
-
-  it('shows an error card when favorites cannot be loaded', async () => {
-    mockUseSession.mockReturnValue({
-      data: { user: { id: 'user-2', name: 'Alex', role: 'user' } },
-      status: 'authenticated',
-      update: jest.fn(),
-    });
-
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
-
-    const { default: ProfilePage } = await import('../profile/page');
-
-    render(<ProfilePage />);
-
-    await waitFor(() =>
-      expect(
-        screen.getByText('We could not load your favorites right now. Please try again later.')
-      ).toBeInTheDocument()
-    );
-  });
-
   it('loads owner review summaries for venue owners', async () => {
     mockUseSession.mockReturnValue({
       data: {
@@ -290,32 +173,58 @@ describe('ProfilePage', () => {
       update: jest.fn(),
     });
 
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ favorites: [] }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          listings: [
-            {
-              slug: 'eco-stay',
-              name: 'Eco Stay',
-              reviews: [
-                {
-                  id: 'rev-1',
-                  rating: 5,
-                  comment: 'Wonderful stay',
-                  createdAt: '2024-02-02T00:00:00.000Z',
-                  reviewerName: 'Jordan',
+    const fetchMock = jest.fn(async input => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/user/reviews')) {
+        return {
+          ok: true,
+          json: async () => ({
+            listings: [
+              {
+                slug: 'eco-stay',
+                name: 'Eco Stay',
+                reviews: [
+                  {
+                    id: 'rev-1',
+                    rating: 5,
+                    comment: 'Wonderful stay',
+                    createdAt: '2024-02-02T00:00:00.000Z',
+                    reviewerName: 'Jordan',
+                  },
+                ],
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url.includes('/api/user/dashboard')) {
+        return {
+          ok: true,
+          json: async () => ({
+            dashboard: {
+              generatedAt: '2024-03-01T00:00:00.000Z',
+              range: { months: 3 },
+              data: {
+                kind: 'venueOwner',
+                totals: {
+                  avgRating: 4.5,
+                  favoritesCount: 10,
+                  reviewCount: 3,
+                  viewCount: 120,
                 },
-              ],
+                listings: [],
+                monthlyTotals: [],
+                notices: [],
+              },
             },
-          ],
-        }),
-      } as Response);
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
 
     global.fetch = fetchMock as unknown as typeof fetch;
 

--- a/app-next-directory/app/profile/page.tsx
+++ b/app-next-directory/app/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Edit, Heart, Loader2, MessageSquare, Star } from 'lucide-react';
+import { Edit, Loader2, MessageSquare, Star } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
@@ -24,19 +24,12 @@ import type {
   UserDashboardPayloadDTO,
   VenueOwnerDashboardDTO,
 } from '@/types/dto';
-import { FavoriteListingsShowcase } from './FavoriteListingsShowcase';
-import type { FavoriteListing, OwnerListingReviews } from './utils';
+import type { OwnerListingReviews } from './utils';
 import {
-  type FavoriteEntry,
   formatDate,
-  normaliseFavorite,
   normaliseOwnerReviews,
   type OwnerReviewsResponse,
 } from './utils';
-
-interface FavoritesResponse {
-  favorites?: Array<FavoriteEntry | null> | null;
-}
 
 type OwnerReviewsResponseApi = OwnerReviewsResponse | null | undefined;
 
@@ -151,10 +144,6 @@ export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState<TabKey>('overview');
   const [isEditing, setIsEditing] = useState(false);
 
-  const [favorites, setFavorites] = useState<FavoriteListing[]>([]);
-  const [favoritesLoading, setFavoritesLoading] = useState(false);
-  const [favoritesError, setFavoritesError] = useState<string | null>(null);
-
   const [ownerListings, setOwnerListings] = useState<OwnerListingReviews[]>([]);
   const [ownerLoading, setOwnerLoading] = useState(false);
   const [ownerError, setOwnerError] = useState<string | null>(null);
@@ -182,38 +171,6 @@ export default function ProfilePage() {
       setIsEditing(false);
     }
   };
-
-  useEffect(() => {
-    if (!isAuthenticated) return;
-    const controller = new AbortController();
-
-    const loadFavorites = async () => {
-      setFavoritesLoading(true);
-      setFavoritesError(null);
-      try {
-        const res = await fetch('/api/user/favorites', { signal: controller.signal });
-        if (!res.ok) {
-          throw new Error('Unable to load favorites');
-        }
-        const data = (await res.json()) as FavoritesResponse;
-        const parsed = (data.favorites ?? [])
-          .map(normaliseFavorite)
-          .filter((favorite): favorite is FavoriteListing => Boolean(favorite));
-        setFavorites(parsed);
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === 'AbortError')) {
-          setFavoritesError('We could not load your favorites right now. Please try again later.');
-        }
-      } finally {
-        setFavoritesLoading(false);
-      }
-    };
-
-    loadFavorites();
-    return () => {
-      controller.abort();
-    };
-  }, [isAuthenticated]);
 
   useEffect(() => {
     if (!isAuthenticated || role !== 'venueOwner') return;
@@ -291,92 +248,6 @@ export default function ProfilePage() {
       setIsEditing(false);
     }
   }, [activeTab, isEditing]);
-
-  const handleRemoveFavorite = async (id: string) => {
-    const originalFavorites = favorites;
-    setFavorites(current => current.filter(favorite => favorite.id !== id));
-
-    try {
-      const response = await fetch(`/api/user/favorites/${id}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) {
-        setFavorites(originalFavorites);
-        setFavoritesError('Failed to remove favorite. Please try again.');
-      }
-    } catch (error) {
-      if (!(error instanceof DOMException && error.name === 'AbortError')) {
-        setFavorites(originalFavorites);
-        setFavoritesError('An error occurred while removing the favorite.');
-      }
-    }
-  };
-
-  const renderFavoriteListingsSection = () => (
-    <section
-      id="favorites"
-      aria-labelledby="favorites-heading"
-      data-testid="profile-favorites"
-      className="space-y-4"
-    >
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h2
-            id="favorites-heading"
-            className="heading-md text-neo-text-primary flex items-center gap-2"
-          >
-            <Heart className="h-5 w-5 text-neo-primary" aria-hidden="true" />
-            Favorite listings
-          </h2>
-          <p className="text-sm text-neo-text-secondary">
-            A quick view of the sustainable venues you&apos;ve saved.
-          </p>
-        </div>
-        <NeoButton asChild variant="secondary">
-          <Link href="/search">Discover more venues</Link>
-        </NeoButton>
-      </div>
-
-      {favoritesLoading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" role="status" aria-live="polite">
-          {Array.from({ length: 3 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-48 animate-pulse rounded-3xl border-4 border-dashed border-neo-border/60 bg-white/60"
-            />
-          ))}
-        </div>
-      ) : favoritesError ? (
-        <NeoCard variant="flat" className="border-4 border-rose-200 bg-rose-50">
-          <NeoCardHeader className="pb-2">
-            <NeoCardTitle className="text-base text-rose-700">
-              We couldn&apos;t load your favorites
-            </NeoCardTitle>
-          </NeoCardHeader>
-          <NeoCardContent className="pt-0 text-sm text-rose-700">{favoritesError}</NeoCardContent>
-        </NeoCard>
-      ) : favorites.length === 0 ? (
-        <NeoCard variant="flat" className="border-4 border-neo-border bg-white/90">
-          <NeoCardContent className="flex flex-col items-start gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="font-semibold text-neo-text-primary">
-                You haven&apos;t saved any venues yet.
-              </p>
-              <p className="text-sm text-neo-text-secondary">
-                Explore eco-friendly spaces and tap the heart icon to save your favorites.
-              </p>
-            </div>
-            <NeoButton asChild variant="accent">
-              <Link href="/search">Start exploring</Link>
-            </NeoButton>
-          </NeoCardContent>
-        </NeoCard>
-      ) : (
-        <FavoriteListingsShowcase listings={favorites} onRemove={handleRemoveFavorite} />
-      )}
-    </section>
-  );
 
   const renderOwnerReviewsSection = () => (
     <section
@@ -937,13 +808,11 @@ export default function ProfilePage() {
                   </section>
                 )}
 
-                {renderFavoriteListingsSection()}
               </div>
             )}
 
             {activeTab === 'favourite' && (
               <div className="space-y-10">
-                {renderFavoriteListingsSection()}
                 <section aria-labelledby="favourite-dashboard" className="space-y-6">
                   <h2 id="favourite-dashboard" className="heading-md">
                     Favourite listing dashboards

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Enhanced documentation structure and discoverability
 - Updated contributing guidelines with changelog workflow
+- Removed the redundant profile favorites section to prevent the 404 error card from stacking with the working favorites dashboard
 
 ## [0.1.3] - 2025-01-XX
 


### PR DESCRIPTION
### Motivation
- The profile page rendered a local favorites section that could show an error card (“favorite is not available right now…”) even when the dashboard-backed favorites component was working, causing a stacked/duplicate UI error.
- The page is gated by authentication, so the fix must preserve existing auth checks and not change how favorites are fetched from the dashboard/API.

### Description
- Removed the duplicated favorites UI and supporting state/effect/handlers from `app-next-directory/app/profile/page.tsx` so only the dashboard-driven favorites view is shown.
- Removed unused imports and normalisation helpers (`FavoriteListingsShowcase`, `normaliseFavorite`, related `favorites` state/effect/handlers) from the profile page to stop the redundant error card from rendering.
- Updated unit tests in `app-next-directory/app/__tests__/profile-page.test.tsx` to reflect the simplified fetch flow and replaced the old showcase mock with a targeted `fetch` mock for the dashboard and owner-review endpoints.
- Added a changelog entry in `docs/reference/CHANGELOG.md` documenting the user-facing change.

### Testing
- Ran `pnpm lint` which completed successfully (biome + eslint hooks passed).
- Ran `pnpm --filter app-next-directory check-types` which reported TypeScript errors originating in `__mocks__` files and therefore failed; these are unrelated mock typing issues uncovered by the check.
- Ran `pnpm test:unit` and all unit suites passed (333 test suites, 4090 tests reported as passing).
- Attempted to run the dev server and capture a Playwright screenshot for manual QA, but Playwright could not connect (dev server returned a redirect/connection refused), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f9c5ebec8323b5a4fd6beeea464c)