### PR TITLE
fix: polish new listing flow (numeric inputs + neo‑brutalist new page)

### DIFF
--- a/app-next-directory/app/dashboard/components/VenueListingForm.tsx
+++ b/app-next-directory/app/dashboard/components/VenueListingForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ChangeEvent } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -148,6 +148,17 @@ type VenueListingFormProps = {
   saving?: boolean;
 };
 
+const handleNumberChange =
+  (onChange: (value: number | undefined) => void) => (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value;
+    if (rawValue === '') {
+      onChange(undefined);
+      return;
+    }
+    const parsed = Number(rawValue);
+    onChange(Number.isNaN(parsed) ? undefined : parsed);
+  };
+
 function toOptions(value: unknown): Option[] {
   if (!Array.isArray(value)) {
     return [];
@@ -289,7 +300,9 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
         galleryImages: galleryImageAssetIds.length > 0 ? galleryImageAssetIds : undefined,
       };
 
-      onSave?.(listingData);
+      if (onSave) {
+        await onSave(listingData);
+      }
     } catch (error) {
       structuredLogger.error('Failed to save listing', error, {
         component: 'VenueListingForm',
@@ -553,7 +566,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Minimum Price Per Night (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -566,7 +584,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Maximum Price Per Night (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -579,7 +602,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Minimum Stay (nights)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -625,7 +653,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Minimum Price Per Person (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -638,7 +671,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Maximum Price Per Person (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -651,7 +689,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Duration</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -685,7 +728,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Minimum Group Size</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -698,7 +746,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Maximum Group Size</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -961,7 +1014,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Maximum Recommended Stay (hours)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -1020,7 +1078,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                       <FormItem>
                         <FormLabel>Price</FormLabel>
                         <FormControl>
-                          <Input type="number" {...field} />
+                          <Input
+                            type="number"
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={handleNumberChange(field.onChange)}
+                          />
                         </FormControl>
                       </FormItem>
                     )}
@@ -1064,7 +1127,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Download Speed (Mbps)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -1077,7 +1145,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Upload Speed (Mbps)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -1377,7 +1450,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Minimum Average Meal Price (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -1390,7 +1468,12 @@ export function VenueListingForm({ listing, onSave, saving = false }: VenueListi
                 <FormItem>
                   <FormLabel>Maximum Average Meal Price (THB)</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} />
+                    <Input
+                      type="number"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field.onChange)}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/app-next-directory/app/dashboard/listings/new/page.tsx
+++ b/app-next-directory/app/dashboard/listings/new/page.tsx
@@ -1,7 +1,16 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { NeoButton } from '@/components/ui/neo-button';
+import {
+  NeoCard,
+  NeoCardContent,
+  NeoCardDescription,
+  NeoCardHeader,
+  NeoCardTitle,
+} from '@/components/ui/neo-card';
 import type { ListingFormValues } from '../../components/VenueListingForm';
 import { VenueListingForm } from '../../components/VenueListingForm';
 export default function NewListingPage() {
@@ -29,10 +38,43 @@ export default function NewListingPage() {
   };
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Add New Listing</h1>
-      {error && <div className="text-red-500 mb-4">{error}</div>}
-      <VenueListingForm onSave={handleSave} />
+    <div className="min-h-screen bg-neo-surface/70 px-4 py-12">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-neo-text-tertiary">
+              Venue owner workspace
+            </p>
+            <h1 className="heading-xl text-neo-text-primary">Add New Listing</h1>
+            <p className="text-sm text-neo-text-secondary">
+              Capture the details that make your space unforgettable for eco-conscious nomads.
+            </p>
+          </div>
+          <NeoButton asChild variant="secondary" className="shadow-[4px_4px_0px_0px_#0f172a]">
+            <Link href="/dashboard/listings">Back to listings</Link>
+          </NeoButton>
+        </header>
+
+        <NeoCard
+          variant="elevated"
+          className="border-4 border-neo-border bg-white/95 shadow-[12px_12px_0px_0px_rgba(15,23,42,0.3)]"
+        >
+          <NeoCardHeader className="space-y-2">
+            <NeoCardTitle>Listing details</NeoCardTitle>
+            <NeoCardDescription className="text-sm text-neo-text-secondary">
+              Share the essentials, amenities, and sustainability features your guests care about.
+            </NeoCardDescription>
+          </NeoCardHeader>
+          <NeoCardContent className="space-y-6">
+            {error && (
+              <div className="rounded-2xl border-4 border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                {error}
+              </div>
+            )}
+            <VenueListingForm onSave={handleSave} />
+          </NeoCardContent>
+        </NeoCard>
+      </div>
     </div>
   );
 }

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced documentation structure and discoverability
 - Updated contributing guidelines with changelog workflow
 - Removed the redundant profile favorites section to prevent the 404 error card from stacking with the working favorites dashboard
+- Refined the new listing workflow styling and stabilized numeric form inputs for venue owners
 
 ## [0.1.3] - 2025-01-XX
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev": "pnpm dev:next",
     "build:next": "pnpm --filter app-next-directory build",
     "build:sanity": "pnpm --filter sanity build",
-    "build": "pnpm build:next | grep -v \"Skipping validation of types\" | grep -v \"Skipping linting\" && pnpm build:sanity | grep -v \"Skipping validation of types\" | grep -v \"Skipping linting\"",
+    "build": "bash -lc 'set -o pipefail; pnpm build:next \"$@\" | grep -v \"Skipping validation of types\" | grep -v \"Skipping linting\" && pnpm build:sanity | grep -v \"Skipping validation of types\" | grep -v \"Skipping linting\"'",
     "start:next": "pnpm --filter app-next-directory start",
     "start:sanity": "pnpm --filter sanity start",
     "start": "pnpm start:next",


### PR DESCRIPTION
### Motivation
- Fix a runtime error users experience when entering numeric values in the new listing form by stabilizing numeric input handling.
- Apply the project Neo‑brutalist styling to the new listing workflow for a consistent owner workspace experience.
- Prevent navigation / race conditions caused by not waiting for form save operations to complete.
- Allow the root `build` invocation to accept the `--debug-prerender` flag used by the quality gate command.

### Description
- Add a `handleNumberChange` helper and apply it to all numeric `Input` fields to coerce empty values and avoid `NaN` propagation.  
- Await the `onSave` call inside `VenueListingForm` so callers reliably observe save completion before navigating.  
- Rework the `/dashboard/listings/new` page to a centered NeoCard layout with `NeoButton` and neo‑brutalist styling for the owner workspace.  
- Update the root `package.json` `build` script to run via `bash -lc` so `pnpm build --debug-prerender` works, and add an entry to the changelog.

### Testing
- Ran `pnpm lint` and the lint pass completed successfully.  
- Ran `pnpm build --debug-prerender` and the Next.js build + prerender steps completed without error.  
- Ran `pnpm test:unit` and all unit tests passed (333 test suites, 4090 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0ae8e060832397d12ac3603833f1)