### PR TITLE
fix: honor admin auth in middleware

### DIFF
--- a/app-next-directory/src/middleware/index.ts
+++ b/app-next-directory/src/middleware/index.ts
@@ -5,7 +5,7 @@
  * NOTE: Do not import NextRequest/NextResponse from 'next/server' in utility files for Next.js 14+ middleware compatibility.
  */
 
-import { auth } from '@/lib/auth';
+import { getToken } from '@/lib/auth';
 import { getRequestContext, structuredLogger } from '@/lib/logger';
 import { ACCESS_CONTROL_MATRIX } from '@/types/auth';
 
@@ -192,9 +192,12 @@ export function createMiddleware(options: MiddlewareOptions) {
 
           return response;
         } else {
-          const homeUrl = new URL('/', request.nextUrl.origin);
-          homeUrl.searchParams.set('error', 'unauthorized_access');
-          const response = options.NextResponse.redirect(homeUrl);
+          const signinUrl = new URL('/auth/login', request.nextUrl.origin);
+          signinUrl.searchParams.set('callbackUrl', pathname);
+          if (token) {
+            signinUrl.searchParams.set('error', 'unauthorized_access');
+          }
+          const response = options.NextResponse.redirect(signinUrl);
 
           // Add security headers
           Object.entries(securityHeaders).forEach(([key, value]) => {
@@ -236,10 +239,12 @@ export function createMiddleware(options: MiddlewareOptions) {
 // Default middleware export for Next.js
 export default function middleware(request: NextRequestLike): Promise<NextResponseLike> {
   const authOptions: MiddlewareOptions = {
-    getToken: async (_req: NextRequestLike) => {
+    getToken: async (req: NextRequestLike) => {
       try {
-        const session = await auth();
-        return session?.user ? { role: session.user.role } : null;
+        return await getToken({
+          req: req as unknown as Request,
+          secret: process.env.NEXTAUTH_SECRET,
+        });
       } catch {
         return null;
       }

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the redundant profile favorites section to prevent the 404 error card from stacking with the working favorites dashboard
 - Refined the new listing workflow styling and stabilized numeric form inputs for venue owners
 
+### Fixed
+- Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in
+
 ## [0.1.3] - 2025-01-XX
 
 ### Added


### PR DESCRIPTION
### Motivation
- Playwright RBAC e2e tests showed admin routes were not being authorised correctly because the middleware did not read NextAuth tokens from the incoming request context. 
- Unauthenticated or non-admin users were redirected to the site root with an `unauthorized_access` flag instead of being sent to the sign-in flow with callback metadata. 
- The middleware needed to rely on `getToken` for request-scoped session inspection to restore correct RBAC behaviour. 

### Description
- Replaced the build-time `auth()` usage with a request-scoped token read via `getToken` by importing `getToken` from `@/lib/auth` in `app-next-directory/src/middleware/index.ts`.
- For non-API admin page access, redirected unauthorised requests to `/auth/login` with `callbackUrl` (and `error=unauthorized_access` only for authenticated users) instead of redirecting to the site root.
- Updated the default middleware `getToken` implementation to forward the original request and `NEXTAUTH_SECRET` to NextAuth `getToken` so session role checks work correctly in runtime.
- Documented the fix in `docs/reference/CHANGELOG.md`.

### Testing
- No automated tests were executed as part of this change.
- Please validate with the Playwright suite using `pnpm test:e2e` and run `pnpm lint` / `pnpm check-types` in CI to confirm RBAC e2e tests are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6f7e15dc832392b4b1b55d77facb)