### PR TITLE
fix(auth): stack login/signup panels and limit social sign-in to Google

### DIFF
--- a/app-next-directory/app/__tests__/auth-login-page.test.tsx
+++ b/app-next-directory/app/__tests__/auth-login-page.test.tsx
@@ -115,7 +115,7 @@ describe('LoginPage', () => {
     expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('footer')).toBeInTheDocument();
     expect(screen.getByTestId('login-form')).toBeInTheDocument();
-    expect(screen.getAllByTestId('social-auth-row')).toHaveLength(2);
+    expect(screen.getAllByTestId('social-auth-row')).toHaveLength(1);
     expect(screen.getByRole('link', { name: /create an account/i })).toHaveAttribute(
       'href',
       '/auth/signup'

--- a/app-next-directory/app/auth/login/__tests__/page.test.tsx
+++ b/app-next-directory/app/auth/login/__tests__/page.test.tsx
@@ -101,7 +101,7 @@ describe('LoginPage', () => {
 
     expect(screen.getByTestId('mock-header')).toBeInTheDocument();
     expect(screen.getByTestId('mock-footer')).toBeInTheDocument();
-    expect(screen.getAllByTestId('mock-social-row')).toHaveLength(3);
+    expect(screen.getAllByTestId('mock-social-row')).toHaveLength(1);
     expect(redirectMock).not.toHaveBeenCalled();
   });
 });

--- a/app-next-directory/app/auth/login/page.tsx
+++ b/app-next-directory/app/auth/login/page.tsx
@@ -48,7 +48,7 @@ export default async function LoginPage(props: LoginPageProps) {
   return (
     <>
       <Header />
-      <div className="relative min-h-screen flex items-center justify-center px-4">
+      <div className="relative min-h-screen flex items-start justify-center px-4 py-12">
         {/* Background accents */}
         <div
           aria-hidden="true"
@@ -62,9 +62,9 @@ export default async function LoginPage(props: LoginPageProps) {
           aria-hidden="true"
           className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl"
         />
-        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+        <div className="w-full max-w-5xl flex flex-col gap-8 md:flex-row md:items-stretch">
           {/* Left panel (visible on all sizes; stacks above auth card on mobile) */}
-          <div className="flex flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
+          <div className="flex flex-1 flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
             <h2 className="heading-lg mb-3" id="welcome-heading">
               Welcome back
             </h2>
@@ -80,7 +80,7 @@ export default async function LoginPage(props: LoginPageProps) {
             </section>
           </div>
           {/* Auth card */}
-          <NeoCard className="p-8 md:p-10">
+          <NeoCard className="flex-1 p-8 md:p-10">
             <NeoCardHeader>
               <NeoCardTitle>Log in</NeoCardTitle>
             </NeoCardHeader>

--- a/app-next-directory/app/auth/signup/SignupPageContent.tsx
+++ b/app-next-directory/app/auth/signup/SignupPageContent.tsx
@@ -35,15 +35,15 @@ export function SignupPageContent() {
   return (
     <>
       <Header />
-      <div className="relative min-h-screen flex items-center justify-center px-4">
+      <div className="relative min-h-screen flex items-start justify-center px-4 py-12">
         {/* Background accents */}
         <div className="absolute inset-0 -z-10 bg-gradient-to-br from-neo-secondary/10 via-white to-neo-primary/10" />
         <div className="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-neo-primary/10 blur-3xl" />
         <div className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl" />
 
-        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+        <div className="w-full max-w-5xl flex flex-col gap-8 md:flex-row md:items-stretch">
           {/* Left panel (visible on all sizes; stacks above auth card on mobile) */}
-          <div className="flex flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
+          <div className="flex flex-1 flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
             <h2 className="heading-lg mb-3">Create your account</h2>
             <p className="body-md">
               Join our eco-forward community and explore sustainable places to live, work, and
@@ -55,7 +55,7 @@ export function SignupPageContent() {
           </div>
 
           {/* Auth card */}
-          <NeoCard className="p-8 md:p-10">
+          <NeoCard className="flex-1 p-8 md:p-10">
             <NeoCardHeader>
               <NeoCardTitle>Sign Up</NeoCardTitle>
             </NeoCardHeader>

--- a/app-next-directory/src/components/auth/SocialAuthRow.tsx
+++ b/app-next-directory/src/components/auth/SocialAuthRow.tsx
@@ -22,36 +22,9 @@ const Icons = {
       />
     </svg>
   ),
-  facebook: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path
-        fill="currentColor"
-        d="M13.5 8.5V7.1c0-.62.41-1.02 1.03-1.02h1.47V3.5h-2.5c-2.07 0-3.5 1.44-3.5 3.6v1.4H8v2.6h1.99V20h3.01v-8.9h2.2l.3-2.6h-2.5z"
-      />
-    </svg>
-  ),
-  twitterx: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path
-        fill="currentColor"
-        d="M18.9 2.5h3.1l-6.78 7.75 7.96 11.25H17.3l-4.96-6.59-5.68 6.59H2.5l7.24-8.4L2 2.5h6.02l4.49 6.01 6.39-6.01z"
-      />
-    </svg>
-  ),
-  microsoft: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path fill="#F25022" d="M3 3h8v8H3z" />
-      <path fill="#7FBA00" d="M13 3h8v8h-8z" />
-      <path fill="#00A4EF" d="M3 13h8v8H3z" />
-      <path fill="#FFB900" d="M13 13h8v8h-8z" />
-    </svg>
-  ),
 };
 
 const PROVIDERS: Provider[] = [
-  { id: 'facebook', name: 'Facebook', color: '#1877F2', fg: '#FFFFFF', icon: Icons.facebook },
-  { id: 'twitter', name: 'X', color: '#000000', fg: '#FFFFFF', icon: Icons.twitterx },
-  { id: 'microsoft', name: 'Microsoft', color: '#F3F4F6', fg: '#111827', icon: Icons.microsoft },
   { id: 'google', name: 'Google', color: '#FFFFFF', fg: '#111827', icon: Icons.google },
 ];
 

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in
+- Stacked login/signup panels on smaller screens and limited social sign-in to Google-only setup
 
 ## [0.1.3] - 2025-01-XX
 


### PR DESCRIPTION
### Motivation
- Prevent login and signup panels from merging at narrow viewports causing duplicated social buttons and visual overlap.
- Ensure the UI reflects the current auth configuration which only exposes Google as a social provider.
- Keep server-side redirect behavior unchanged while fixing layout and provider surface area.

### Description
- Reworked auth page layouts to stack vertically on small screens by replacing the grid with a responsive `flex` column and adding `py-12` and `items-start` for stable vertical spacing in `LoginPage` and `SignupPageContent`.
- Made the left panel and auth card equally flexible by adding `flex-1` to the panels and `NeoCard` to maintain consistent sizing when stacked.
- Reduced `SocialAuthRow` provider list to Google-only and removed other provider icons so available social sign-ins match the configured provider set.
- Updated server-side and component tests to expect the single social auth row and added a changelog entry describing the fix.

### Testing
- Started the Next.js dev server with `pnpm dev:next` which compiled the app and served the pages (dev server start succeeded).
- Ran a Playwright script that loaded `/auth/login` at a mobile viewport and produced a screenshot `artifacts/auth-login-mobile.png` to verify stacking visually (script succeeded).
- No Jest unit test run was performed as part of this rollout, so unit test suites were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b47dfaf748323b900f27ee3626c0d)