### PR TITLE
fix(auth): stack auth panels on mobile and limit social auth to Google

### DIFF
--- a/app-next-directory/app/__tests__/auth-login-page.test.tsx
+++ b/app-next-directory/app/__tests__/auth-login-page.test.tsx
@@ -115,7 +115,7 @@ describe('LoginPage', () => {
     expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('footer')).toBeInTheDocument();
     expect(screen.getByTestId('login-form')).toBeInTheDocument();
-    expect(screen.getAllByTestId('social-auth-row')).toHaveLength(2);
+    expect(screen.getAllByTestId('social-auth-row')).toHaveLength(1);
     expect(screen.getByRole('link', { name: /create an account/i })).toHaveAttribute(
       'href',
       '/auth/signup'

--- a/app-next-directory/app/auth/login/__tests__/page.test.tsx
+++ b/app-next-directory/app/auth/login/__tests__/page.test.tsx
@@ -101,7 +101,7 @@ describe('LoginPage', () => {
 
     expect(screen.getByTestId('mock-header')).toBeInTheDocument();
     expect(screen.getByTestId('mock-footer')).toBeInTheDocument();
-    expect(screen.getAllByTestId('mock-social-row')).toHaveLength(3);
+    expect(screen.getAllByTestId('mock-social-row')).toHaveLength(1);
     expect(redirectMock).not.toHaveBeenCalled();
   });
 });

--- a/app-next-directory/app/auth/login/page.tsx
+++ b/app-next-directory/app/auth/login/page.tsx
@@ -48,7 +48,7 @@ export default async function LoginPage(props: LoginPageProps) {
   return (
     <>
       <Header />
-      <div className="relative min-h-screen flex items-center justify-center px-4">
+      <div className="relative min-h-screen flex items-start justify-center px-4 py-12">
         {/* Background accents */}
         <div
           aria-hidden="true"
@@ -62,9 +62,9 @@ export default async function LoginPage(props: LoginPageProps) {
           aria-hidden="true"
           className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl"
         />
-        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+        <div className="w-full max-w-5xl flex flex-col gap-8 md:flex-row md:items-stretch">
           {/* Left panel (visible on all sizes; stacks above auth card on mobile) */}
-          <div className="flex flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
+          <div className="flex w-full flex-col justify-center rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5 p-6 md:w-auto md:flex-1 md:p-8">
             <h2 className="heading-lg mb-3" id="welcome-heading">
               Welcome back
             </h2>
@@ -80,7 +80,7 @@ export default async function LoginPage(props: LoginPageProps) {
             </section>
           </div>
           {/* Auth card */}
-          <NeoCard className="p-8 md:p-10">
+          <NeoCard className="w-full p-8 md:w-auto md:flex-1 md:p-10">
             <NeoCardHeader>
               <NeoCardTitle>Log in</NeoCardTitle>
             </NeoCardHeader>

--- a/app-next-directory/app/auth/signup/SignupPageContent.tsx
+++ b/app-next-directory/app/auth/signup/SignupPageContent.tsx
@@ -35,15 +35,15 @@ export function SignupPageContent() {
   return (
     <>
       <Header />
-      <div className="relative min-h-screen flex items-center justify-center px-4">
+      <div className="relative min-h-screen flex items-start justify-center px-4 py-12">
         {/* Background accents */}
         <div className="absolute inset-0 -z-10 bg-gradient-to-br from-neo-secondary/10 via-white to-neo-primary/10" />
         <div className="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-neo-primary/10 blur-3xl" />
         <div className="absolute -bottom-24 -right-24 w-72 h-72 rounded-full bg-neo-secondary/10 blur-3xl" />
 
-        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+        <div className="w-full max-w-5xl flex flex-col gap-8 md:flex-row md:items-stretch">
           {/* Left panel (visible on all sizes; stacks above auth card on mobile) */}
-          <div className="flex flex-col justify-center p-6 md:p-8 rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5">
+          <div className="flex w-full flex-col justify-center rounded-xl neo-card bg-gradient-to-br from-white to-neo-secondary/5 p-6 md:w-auto md:flex-1 md:p-8">
             <h2 className="heading-lg mb-3">Create your account</h2>
             <p className="body-md">
               Join our eco-forward community and explore sustainable places to live, work, and
@@ -55,7 +55,7 @@ export function SignupPageContent() {
           </div>
 
           {/* Auth card */}
-          <NeoCard className="p-8 md:p-10">
+          <NeoCard className="w-full p-8 md:w-auto md:flex-1 md:p-10">
             <NeoCardHeader>
               <NeoCardTitle>Sign Up</NeoCardTitle>
             </NeoCardHeader>

--- a/app-next-directory/src/components/auth/SocialAuthRow.tsx
+++ b/app-next-directory/src/components/auth/SocialAuthRow.tsx
@@ -22,36 +22,9 @@ const Icons = {
       />
     </svg>
   ),
-  facebook: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path
-        fill="currentColor"
-        d="M13.5 8.5V7.1c0-.62.41-1.02 1.03-1.02h1.47V3.5h-2.5c-2.07 0-3.5 1.44-3.5 3.6v1.4H8v2.6h1.99V20h3.01v-8.9h2.2l.3-2.6h-2.5z"
-      />
-    </svg>
-  ),
-  twitterx: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path
-        fill="currentColor"
-        d="M18.9 2.5h3.1l-6.78 7.75 7.96 11.25H17.3l-4.96-6.59-5.68 6.59H2.5l7.24-8.4L2 2.5h6.02l4.49 6.01 6.39-6.01z"
-      />
-    </svg>
-  ),
-  microsoft: (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="w-5 h-5">
-      <path fill="#F25022" d="M3 3h8v8H3z" />
-      <path fill="#7FBA00" d="M13 3h8v8h-8z" />
-      <path fill="#00A4EF" d="M3 13h8v8H3z" />
-      <path fill="#FFB900" d="M13 13h8v8h-8z" />
-    </svg>
-  ),
 };
 
 const PROVIDERS: Provider[] = [
-  { id: 'facebook', name: 'Facebook', color: '#1877F2', fg: '#FFFFFF', icon: Icons.facebook },
-  { id: 'twitter', name: 'X', color: '#000000', fg: '#FFFFFF', icon: Icons.twitterx },
-  { id: 'microsoft', name: 'Microsoft', color: '#F3F4F6', fg: '#111827', icon: Icons.microsoft },
   { id: 'google', name: 'Google', color: '#FFFFFF', fg: '#111827', icon: Icons.google },
 ];
 

--- a/app-next-directory/src/components/auth/__tests__/SocialAuthRow.test.tsx
+++ b/app-next-directory/src/components/auth/__tests__/SocialAuthRow.test.tsx
@@ -21,7 +21,7 @@ describe('SocialAuthRow', () => {
       expect(screen.getByText(/Loading sign-in options/i)).toBeInTheDocument();
     });
 
-    it('renders provider buttons when loaded successfully', async () => {
+    it('renders only configured provider buttons when loaded successfully', async () => {
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -35,10 +35,10 @@ describe('SocialAuthRow', () => {
       render(<SocialAuthRow />);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/Continue with Facebook/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/Continue with Google/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/Continue with X/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/Continue with Microsoft/i)).toBeInTheDocument();
+        expect(screen.queryByLabelText(/Continue with Facebook/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Continue with X/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Continue with Microsoft/i)).not.toBeInTheDocument();
       });
     });
 
@@ -167,17 +167,14 @@ describe('SocialAuthRow', () => {
     it('renders buttons with correct icons', async () => {
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          facebook: { id: 'facebook' },
-          google: { id: 'google' },
-        }),
+        json: async () => ({ google: { id: 'google' } }),
       } as Response);
 
       const { container } = render(<SocialAuthRow />);
 
       await waitFor(() => {
         const buttons = container.querySelectorAll('button');
-        expect(buttons).toHaveLength(2);
+        expect(buttons).toHaveLength(1);
 
         // Each button should have an SVG icon
         buttons.forEach(button => {
@@ -189,18 +186,12 @@ describe('SocialAuthRow', () => {
     it('renders buttons with correct colors', async () => {
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          facebook: { id: 'facebook' },
-          google: { id: 'google' },
-        }),
+        json: async () => ({ google: { id: 'google' } }),
       } as Response);
 
       render(<SocialAuthRow />);
 
       await waitFor(() => {
-        const facebookButton = screen.getByLabelText(/Continue with Facebook/i);
-        expect(facebookButton).toHaveStyle({ backgroundColor: '#1877F2' });
-
         const googleButton = screen.getByLabelText(/Continue with Google/i);
         expect(googleButton).toHaveStyle({ backgroundColor: '#FFFFFF' });
       });
@@ -289,30 +280,44 @@ describe('SocialAuthRow', () => {
     });
 
     it('only disables the clicked button, not other buttons', async () => {
+      const customProviders = [
+        {
+          id: 'custom',
+          name: 'Custom',
+          color: '#000000',
+          fg: '#FFFFFF',
+          icon: <span>Custom</span>,
+        },
+        {
+          id: 'google',
+          name: 'Google',
+          color: '#FFFFFF',
+          fg: '#111827',
+          icon: <span>Google</span>,
+        },
+      ];
+
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          google: { id: 'google' },
-          facebook: { id: 'facebook' },
-        }),
+        json: async () => ({ google: { id: 'google' }, custom: { id: 'custom' } }),
       } as Response);
 
       mockSignIn.mockImplementation(() => new Promise(() => {}));
 
-      render(<SocialAuthRow />);
+      render(<SocialAuthRow providers={customProviders} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText(/Continue with Google/i)).toBeInTheDocument();
       });
 
       const googleButton = screen.getByLabelText(/Continue with Google/i);
-      const facebookButton = screen.getByLabelText(/Continue with Facebook/i);
+      const customButton = screen.getByLabelText(/Continue with Custom/i);
 
       await userEvent.click(googleButton);
 
       await waitFor(() => {
         expect(googleButton).toBeDisabled();
-        expect(facebookButton).toBeEnabled();
+        expect(customButton).toBeEnabled();
       });
     });
 
@@ -500,16 +505,40 @@ describe('SocialAuthRow', () => {
     });
 
     it('renders multiple providers in a row', async () => {
+      const customProviders = [
+        {
+          id: 'google',
+          name: 'Google',
+          color: '#FFFFFF',
+          fg: '#111827',
+          icon: <span>Google</span>,
+        },
+        {
+          id: 'custom-1',
+          name: 'Custom 1',
+          color: '#111111',
+          fg: '#FFFFFF',
+          icon: <span>Custom 1</span>,
+        },
+        {
+          id: 'custom-2',
+          name: 'Custom 2',
+          color: '#222222',
+          fg: '#FFFFFF',
+          icon: <span>Custom 2</span>,
+        },
+      ];
+
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          facebook: { id: 'facebook' },
           google: { id: 'google' },
-          twitter: { id: 'twitter' },
+          'custom-1': { id: 'custom-1' },
+          'custom-2': { id: 'custom-2' },
         }),
       } as Response);
 
-      const { container } = render(<SocialAuthRow />);
+      const { container } = render(<SocialAuthRow providers={customProviders} />);
 
       await waitFor(() => {
         const buttons = container.querySelectorAll('button');
@@ -532,51 +561,6 @@ describe('SocialAuthRow', () => {
         const svg = googleButton.querySelector('svg');
         expect(svg).toBeInTheDocument();
         expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
-      });
-    });
-
-    it('renders Facebook icon', async () => {
-      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ facebook: { id: 'facebook' } }),
-      } as Response);
-
-      render(<SocialAuthRow />);
-
-      await waitFor(() => {
-        const facebookButton = screen.getByLabelText(/Continue with Facebook/i);
-        const svg = facebookButton.querySelector('svg');
-        expect(svg).toBeInTheDocument();
-      });
-    });
-
-    it('renders Twitter/X icon', async () => {
-      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ twitter: { id: 'twitter' } }),
-      } as Response);
-
-      render(<SocialAuthRow />);
-
-      await waitFor(() => {
-        const twitterButton = screen.getByLabelText(/Continue with X/i);
-        const svg = twitterButton.querySelector('svg');
-        expect(svg).toBeInTheDocument();
-      });
-    });
-
-    it('renders Microsoft icon', async () => {
-      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ microsoft: { id: 'microsoft' } }),
-      } as Response);
-
-      render(<SocialAuthRow />);
-
-      await waitFor(() => {
-        const microsoftButton = screen.getByLabelText(/Continue with Microsoft/i);
-        const svg = microsoftButton.querySelector('svg');
-        expect(svg).toBeInTheDocument();
       });
     });
 
@@ -663,17 +647,14 @@ describe('SocialAuthRow', () => {
     it('provides proper button roles', async () => {
       jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          google: { id: 'google' },
-          facebook: { id: 'facebook' },
-        }),
+        json: async () => ({ google: { id: 'google' } }),
       } as Response);
 
       render(<SocialAuthRow />);
 
       await waitFor(() => {
         const buttons = screen.getAllByRole('button');
-        expect(buttons).toHaveLength(2);
+        expect(buttons).toHaveLength(1);
       });
     });
 

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in
+- Stacked login/signup panels on smaller screens and limited social sign-in to Google-only setup
 
 ## [0.1.3] - 2025-01-XX
 


### PR DESCRIPTION
### Motivation
- Prevent login and signup panels from collapsing into each other at narrow viewports which caused duplicated buttons and visual overlap.
- Surface only the actually-configured social provider so the UI matches the app auth configuration (Google-only).
- Keep server-side redirect and auth behavior unchanged while fixing layout and the provider surface area.

### Description
- Replaced the grid layout with a responsive `flex` column and added spacing classes so the auth left panel and auth card stack cleanly on small viewports in `LoginPage` and `SignupPageContent`.
- Made the left panel and auth card stretch full-width when stacked by adding `w-full` and coordinated `md:w-auto md:flex-1`/`md:p-*` adjustments and updated `NeoCard` sizing classes.
- Reduced `SocialAuthRow` provider surface to a Google-only `PROVIDERS` list and removed other provider icons and brand markup.
- Updated unit tests (`SocialAuthRow.test.tsx` and auth page tests) to expect the Google-only provider set and added test cases for custom provider injection, and added a changelog entry.

### Testing
- Ran `pnpm lint` which completed successfully with no fixes applied by the tooling.
- Started the Next.js dev server (`pnpm dev:next`), set `NEXTAUTH_SECRET=dev` to avoid `MissingSecret` errors, and verified pages rendered and responded (dev server started successfully).
- Captured mobile screenshots of `/auth/login` and `/auth/signup` via Playwright after switching to Firefox when Chromium had a headless crash, and the screenshots were produced.
- Ran unit tests with `pnpm test:unit` and all suites passed (`333` test suites, `4087` tests); TypeScript full-check (`tsc --noEmit`) at app-level still reported errors in `__mocks__`, and the root `check-types` helper is not present, so type-checking remains failing in CI until mocks are reconciled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b47dfaf748323b900f27ee3626c0d)