### PR TITLE
fix: add E2E setup-user endpoint for Playwright auth

### DIFF
--- a/app-next-directory/app/api/e2e/setup-user/route.ts
+++ b/app-next-directory/app/api/e2e/setup-user/route.ts
@@ -1,0 +1,121 @@
+import bcrypt from 'bcryptjs';
+import { NextResponse, type NextRequest } from 'next/server';
+import connect from '@/lib/dbConnect';
+import structuredLogger from '@/lib/logger';
+import User, { BCRYPT_COST, ROLE_VALUES, type Role } from '@/models/User';
+
+const isE2EEnvironment = process.env.E2E === '1' || process.env.NEXT_PUBLIC_E2E === '1';
+
+const normalizeEmail = (value: string) => value.trim().toLowerCase();
+
+export async function POST(request: NextRequest) {
+  if (!isE2EEnvironment) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  if (!process.env.MONGODB_URI) {
+    structuredLogger.warn('MONGODB_URI is not set; responding 503 from /api/e2e/setup-user', {
+      component: 'e2e',
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'MISSING_DB_CONFIG',
+          message: 'MONGODB_URI not configured in environment; E2E setup disabled',
+        },
+      },
+      { status: 503, headers: { 'Retry-After': '60' } }
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    const errorForLog = error instanceof Error ? error : new Error(String(error));
+    structuredLogger.warn('[e2e/setup-user] Failed to parse request body', {
+      component: 'e2e',
+      error: errorForLog.message,
+    });
+    return NextResponse.json(
+      { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+      { status: 400 }
+    );
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json(
+      { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+      { status: 400 }
+    );
+  }
+
+  const { email, password, role, name } = payload as Partial<{
+    email: string;
+    password: string;
+    role: Role;
+    name: string;
+  }>;
+
+  const normalizedEmail = typeof email === 'string' ? normalizeEmail(email) : '';
+  const requestedRole = role && ROLE_VALUES.includes(role) ? role : null;
+
+  if (!normalizedEmail || typeof password !== 'string' || password.trim().length === 0) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Invalid request body', code: 'INVALID_INPUT' } },
+      { status: 400 }
+    );
+  }
+
+  const resolvedRole = requestedRole ?? 'user';
+  const resolvedName =
+    typeof name === 'string' && name.trim().length > 0 ? name.trim() : `E2E ${resolvedRole} User`;
+
+  try {
+    await connect();
+
+    const hashedPassword = await bcrypt.hash(password, BCRYPT_COST);
+
+    const userDoc = await User.findOneAndUpdate(
+      { email: normalizedEmail },
+      {
+        $set: {
+          name: resolvedName,
+          email: normalizedEmail,
+          password: hashedPassword,
+          role: resolvedRole,
+          status: 'active',
+          emailVerified: new Date(),
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          user: {
+            id: String(userDoc?._id ?? ''),
+            email: userDoc?.email ?? normalizedEmail,
+            role: userDoc?.role ?? resolvedRole,
+          },
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    structuredLogger.error('[e2e/setup-user] Failed to setup user', error, {
+      component: 'e2e',
+      email: normalizedEmail,
+      role: resolvedRole,
+    });
+    const message = error instanceof Error ? error.message : 'Internal Server Error';
+    return NextResponse.json(
+      { success: false, error: { message, code: 'SERVER_ERROR' } },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
### Motivation

- E2E authentication and RBAC Playwright specs require programmatic seeding of test users so tests can reliably log in and exercise admin routes.
- The test helpers expect an `/api/e2e/setup-user` endpoint to create or update users server-side for deterministic role-based checks.
- Without a guarded server-side seeding route, CI/local E2E runs can fail due to missing users or session data.

### Description

- Add a new API route `app-next-directory/app/api/e2e/setup-user/route.ts` that exposes a `POST` handler to create or update E2E test users.
- Gate the endpoint to E2E mode (`E2E` or `NEXT_PUBLIC_E2E` set) and return a clear 503 when `MONGODB_URI` is not configured.
- Validate and normalize the incoming payload, hash the password with `bcrypt`, and `findOneAndUpdate` with `upsert` to create or update the user and mark `emailVerified`/`status`.
- Log warnings and errors via `structuredLogger` and return structured JSON error responses for invalid input or server failures.

### Testing

- No automated tests were executed against this change as part of this patch.
- The route includes defensive checks that will return 404 when not in E2E mode and 503 when DB config is missing to avoid accidental use in non-test environments.
- Playwright E2E suites (e.g., `tests/e2e/auth.spec.ts` and `tests/e2e/rbac.e2e.spec.ts`) can now call `POST /api/e2e/setup-user` to seed users prior to login flows.
- Recommend running `pnpm test:e2e` in an isolated E2E environment to validate the full flow after deploying this route.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531d83131c832396906baaa120ea38)