### PR TITLE
feat: open admin listing edits in modal

### DIFF
--- a/app-next-directory/app/admin/listings/EditListingModal.tsx
+++ b/app-next-directory/app/admin/listings/EditListingModal.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useState } from 'react';
+import { NeoButton } from '@/components/ui/neo-button';
+import {
+  NeoCard,
+  NeoCardContent,
+  NeoCardDescription,
+  NeoCardHeader,
+  NeoCardTitle,
+} from '@/components/ui/neo-card';
+import { getUserFacingMessage } from '@/lib/client-utils';
+import type { ListingFormValues } from '../../../dashboard/components/VenueListingForm';
+import { VenueListingForm } from '../../../dashboard/components/VenueListingForm';
+
+type EditListingModalProps = {
+  listingId: string;
+  listingName: string;
+  onUpdated: () => void;
+};
+
+type ListingFormState = ListingFormValues & Record<string, unknown>;
+
+type ListingResponse = ListingFormState;
+
+type SaveResponse = { message?: string };
+
+export function EditListingModal({
+  listingId,
+  listingName,
+  onUpdated,
+}: EditListingModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [listing, setListing] = useState<ListingFormState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const fetchListing = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/listings/manage/${listingId}`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch listing');
+        }
+        const data = (await response.json()) as ListingResponse;
+        setListing(data);
+      } catch (err) {
+        setError(getUserFacingMessage(err, 'An unexpected error occurred'));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchListing();
+  }, [isOpen, listingId]);
+
+  const handleSave = async (data: ListingFormState) => {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/listings/manage/${listingId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as SaveResponse;
+        throw new Error(payload.message ?? 'Failed to update listing');
+      }
+
+      onUpdated();
+      setIsOpen(false);
+    } catch (err) {
+      setError(getUserFacingMessage(err, 'An error occurred while saving'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={open => {
+        setIsOpen(open);
+        if (!open) {
+          setError(null);
+          setListing(null);
+        }
+      }}
+    >
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="text-blue-600 hover:text-blue-900"
+          title={`Edit ${listingName}`}
+        >
+          ✎
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(92vw,64rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-3xl border-4 border-neo-border bg-neo-surface shadow-[12px_12px_0px_0px_rgba(15,23,42,0.35)]">
+          <div className="max-h-[90vh] overflow-y-auto px-6 py-8">
+            <header className="flex flex-wrap items-start justify-between gap-4">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-neo-text-tertiary">
+                  Admin workspace
+                </p>
+                <Dialog.Title className="heading-xl text-neo-text-primary">
+                  Edit Listing
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-neo-text-secondary">
+                  Update details, amenities, and sustainability highlights for {listingName}.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <NeoButton variant="secondary" className="shadow-[4px_4px_0px_0px_#0f172a]">
+                  Close
+                </NeoButton>
+              </Dialog.Close>
+            </header>
+
+            <NeoCard
+              variant="elevated"
+              className="mt-6 border-4 border-neo-border bg-white/95 shadow-[12px_12px_0px_0px_rgba(15,23,42,0.3)]"
+            >
+              <NeoCardHeader className="space-y-2">
+                <NeoCardTitle>Listing details</NeoCardTitle>
+                <NeoCardDescription className="text-sm text-neo-text-secondary">
+                  Keep listing information up to date for the community.
+                </NeoCardDescription>
+              </NeoCardHeader>
+              <NeoCardContent className="space-y-6">
+                {error && (
+                  <div className="rounded-2xl border-4 border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                    {error}
+                  </div>
+                )}
+                {loading ? (
+                  <div className="rounded-2xl border border-dashed border-neo-border/60 bg-neo-surface/70 px-6 py-8 text-center text-sm text-neo-text-secondary">
+                    Loading listing details...
+                  </div>
+                ) : (
+                  listing && (
+                    <VenueListingForm listing={listing} onSave={handleSave} saving={saving} />
+                  )
+                )}
+              </NeoCardContent>
+            </NeoCard>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app-next-directory/app/admin/listings/ListingsManagementTable.tsx
+++ b/app-next-directory/app/admin/listings/ListingsManagementTable.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useCallback, useEffect, useState, useTransition } from 'react';
 import { NeoButton } from '@/components/ui/neo-button';
 import { getUserFacingMessage } from '@/lib/client-utils';
@@ -14,6 +13,7 @@ import {
   type ListingManagementResponse,
   type ListingWorkflowStatus,
 } from '@/types/listings';
+import { EditListingModal } from './EditListingModal';
 
 type ListingsManagementTableProps = {
   currentUserRole?: 'admin' | 'superAdmin';
@@ -479,15 +479,21 @@ export function ListingsManagementTable(_props: ListingsManagementTableProps) {
                       <span className="text-blue-600">{actionStatus.message}</span>
                     ) : (
                       <div className="flex gap-2">
-                        <Link href={`/admin/listings/edit/${listing.id}`} legacyBehavior>
-                          <a
-                            href={`/admin/listings/edit/${listing.id}`}
-                            className="text-blue-600 hover:text-blue-900"
-                            title="Edit listing"
-                          >
-                            ✎
-                          </a>
-                        </Link>
+                        <EditListingModal
+                          listingId={listing.id}
+                          listingName={listing.name}
+                          onUpdated={() =>
+                            void Promise.all([
+                              loadListings(
+                                pagination.page,
+                                filters.search,
+                                filters.status,
+                                filters.type
+                              ),
+                              loadStats(),
+                            ])
+                          }
+                        />
                         {listing.status !== 'published' && (
                           <button
                             type="button"

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated contributing guidelines with changelog workflow
 - Removed the redundant profile favorites section to prevent the 404 error card from stacking with the working favorites dashboard
 - Refined the new listing workflow styling and stabilized numeric form inputs for venue owners
+- Updated the admin listings edit flow to use the new listing UI inside a modal popup
 
 ### Fixed
 - Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in


### PR DESCRIPTION
### Motivation
- Make the admin listings edit experience match the new listing UI by surfacing the edit form as an in-place modal instead of navigating away to a separate page.
- Reuse the existing `VenueListingForm` and Neo UI so editing and creating listings share the same design and validation behaviors.
- Reduce context switching for administrators and allow the listings table to refresh in-place after an edit is saved.

### Description
- Added a new `EditListingModal` component at `app-next-directory/app/admin/listings/EditListingModal.tsx` that uses `@radix-ui/react-dialog` and reuses `VenueListingForm` for the edit UI.
- Replaced the edit link in `ListingsManagementTable` with the modal trigger and wired the modal `onUpdated` callback to reload listings and stats after save.
- Updated `docs/reference/CHANGELOG.md` to document the admin listings edit flow change.

### Testing
- Started the dev server with `pnpm dev:next` and exercised the admin listings page to validate the modal is reachable in the UI, noting the dev environment redirected to sign-in due to a missing Auth secret.
- Ran a small Playwright script that captured a screenshot of the `/admin/listings` route and produced an artifact (`artifacts/admin-listings.png`).
- No unit or integration test suites were executed as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d37d65f08323a142e6a3f8fd1438)