### PR TITLE
feat: centralize cache revalidation handlers

### DIFF
--- a/app-next-directory/app/api/revalidate-all/route.ts
+++ b/app-next-directory/app/api/revalidate-all/route.ts
@@ -1,6 +1,6 @@
-import { revalidatePath } from 'next/cache';
 import type { NextRequest } from 'next/server';
 import { getRequestContext, structuredLogger } from '@/lib/logger';
+import { REVALIDATE_ALL_ROUTES, revalidatePaths } from '@/lib/revalidation';
 import { ApiResponseHandler } from '@/utils/api-response';
 import { validateRevalidationToken } from '@/utils/revalidation-token';
 
@@ -33,14 +33,10 @@ export async function POST(request: NextRequest) {
       return ApiResponseHandler.error('Invalid token', 401);
     }
 
-    // Revalidate all dynamic routes
-    const routesToRevalidate = ['/', '/listings', '/category', '/city'];
+    const routesToRevalidate = [...REVALIDATE_ALL_ROUTES];
 
-    // Revalidate each route
-    const revalidate = _testControl?.revalidatePathOverride ?? revalidatePath;
-    for (const route of routesToRevalidate) {
-      revalidate(route);
-    }
+    const revalidate = _testControl?.revalidatePathOverride;
+    revalidatePaths(routesToRevalidate, revalidate);
 
     // Access Date.now() after reading uncached data (revalidatePath) to avoid prerender bailout
     return ApiResponseHandler.success({

--- a/app-next-directory/app/api/revalidate/route.ts
+++ b/app-next-directory/app/api/revalidate/route.ts
@@ -2,6 +2,7 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import type { NextRequest } from 'next/server';
 import { connection } from 'next/server';
 import { structuredLogger } from '@/lib/logger';
+import { ALLOWED_REVALIDATION_TAGS, TAG_PATTERN } from '@/lib/revalidation';
 import { ApiResponseHandler } from '@/utils/api-response';
 import { validateRevalidationToken } from '@/utils/revalidation-token';
 
@@ -53,9 +54,6 @@ export async function GET(request: NextRequest) {
     return ApiResponseHandler.error('Error revalidating', 500);
   }
 }
-
-const ALLOWED_REVALIDATION_TAGS = new Set(['featured-listings', 'cities', 'eco-tags', 'home']);
-const TAG_PATTERN = /^[a-z0-9:-]+$/i;
 
 export async function POST(request: NextRequest) {
   await connection();

--- a/app-next-directory/app/api/sanity/webhook/route.ts
+++ b/app-next-directory/app/api/sanity/webhook/route.ts
@@ -2,21 +2,10 @@ import { revalidateTag } from 'next/cache';
 import type { NextRequest } from 'next/server';
 import { connection } from 'next/server';
 import { structuredLogger } from '@/lib/logger';
+import type { SanityWebhookPayload } from '@/lib/revalidation';
+import { resolveSanityRevalidationTargets, revalidateTags } from '@/lib/revalidation';
 import { ApiResponseHandler } from '@/utils/api-response';
 import { validateRevalidationToken } from '@/utils/revalidation-token';
-
-type SanityWebhookPayload = {
-  _type?: string;
-  type?: string;
-  document?: { _type?: string; slug?: { current?: string } };
-  ids?: { created?: string[]; updated?: string[]; deleted?: string[] };
-};
-
-const TAGS_BY_TYPE: Record<string, string[]> = {
-  listing: ['featured-listings'],
-  city: ['cities'],
-  ecoTag: ['eco-tags'],
-};
 
 export async function POST(request: NextRequest) {
   await connection();
@@ -30,38 +19,12 @@ export async function POST(request: NextRequest) {
       return ApiResponseHandler.error('Invalid token', 401);
     }
 
-    const docType = payload?._type ?? payload?.document?._type ?? payload?.type ?? null;
-    const tags = new Set<string>(['home']);
-
-    if (docType && TAGS_BY_TYPE[docType]) {
-      TAGS_BY_TYPE[docType].forEach(tag => tags.add(tag));
-    }
-
-    // Attempt to revalidate listing-specific tags if payload provides slugs/ids
-    const listingSlugs: string[] = [];
-    if (docType === 'listing') {
-      const docSlug = payload?.document?.slug?.current;
-      if (typeof docSlug === 'string' && docSlug.length > 0) listingSlugs.push(docSlug);
-      const ids = [
-        ...(payload?.ids?.created ?? []),
-        ...(payload?.ids?.updated ?? []),
-        ...(payload?.ids?.deleted ?? []),
-      ];
-      for (const idOrSlug of ids) {
-        if (typeof idOrSlug === 'string' && idOrSlug.length > 0) listingSlugs.push(idOrSlug);
-      }
-    }
-
-    tags.forEach(tag => revalidateTag(tag, 'max'));
-    for (const s of Array.from(new Set(listingSlugs))) {
-      try {
-        revalidateTag(`listing-${s}`, 'max');
-      } catch {}
-    }
+    const { docType, tags, listingSlugs } = resolveSanityRevalidationTargets(payload);
+    revalidateTags(tags, listingSlugs, revalidateTag);
 
     return ApiResponseHandler.success({
       revalidated: true,
-      tags: Array.from(tags),
+      tags,
       docType,
       now: Date.now(),
     });

--- a/app-next-directory/src/lib/revalidation.ts
+++ b/app-next-directory/src/lib/revalidation.ts
@@ -1,0 +1,76 @@
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+export type SanityWebhookPayload = {
+  _type?: string;
+  type?: string;
+  document?: { _type?: string; slug?: { current?: string } };
+  ids?: { created?: string[]; updated?: string[]; deleted?: string[] };
+};
+
+const SANITY_TAGS_BY_TYPE: Record<string, string[]> = {
+  listing: ['featured-listings'],
+  city: ['cities'],
+  ecoTag: ['eco-tags'],
+};
+
+export const ALLOWED_REVALIDATION_TAGS = new Set([
+  'featured-listings',
+  'cities',
+  'eco-tags',
+  'home',
+]);
+
+export const TAG_PATTERN = /^[a-z0-9:-]+$/i;
+
+export const REVALIDATE_ALL_ROUTES = ['/', '/listings', '/category', '/city'];
+
+export const resolveSanityRevalidationTargets = (payload: SanityWebhookPayload | null) => {
+  const docType = payload?._type ?? payload?.document?._type ?? payload?.type ?? null;
+  const tags = new Set<string>(['home']);
+
+  if (docType && SANITY_TAGS_BY_TYPE[docType]) {
+    SANITY_TAGS_BY_TYPE[docType].forEach(tag => tags.add(tag));
+  }
+
+  const listingSlugs: string[] = [];
+  if (docType === 'listing') {
+    const docSlug = payload?.document?.slug?.current;
+    if (typeof docSlug === 'string' && docSlug.length > 0) listingSlugs.push(docSlug);
+    const ids = [
+      ...(payload?.ids?.created ?? []),
+      ...(payload?.ids?.updated ?? []),
+      ...(payload?.ids?.deleted ?? []),
+    ];
+    for (const idOrSlug of ids) {
+      if (typeof idOrSlug === 'string' && idOrSlug.length > 0) listingSlugs.push(idOrSlug);
+    }
+  }
+
+  return {
+    docType,
+    tags: Array.from(tags),
+    listingSlugs: Array.from(new Set(listingSlugs)),
+  };
+};
+
+export const revalidateTags = (
+  tags: string[],
+  listingSlugs: string[],
+  revalidateTagFn: (tag: string, type?: 'layout' | 'page' | 'max') => void = revalidateTag
+) => {
+  tags.forEach(tag => revalidateTagFn(tag, 'max'));
+  for (const slug of listingSlugs) {
+    try {
+      revalidateTagFn(`listing-${slug}`, 'max');
+    } catch {}
+  }
+};
+
+export const revalidatePaths = (
+  paths: string[],
+  revalidatePathFn: (path: string) => void = revalidatePath
+) => {
+  for (const path of paths) {
+    revalidatePathFn(path);
+  }
+};

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated contributing guidelines with changelog workflow
 - Removed the redundant profile favorites section to prevent the 404 error card from stacking with the working favorites dashboard
 - Refined the new listing workflow styling and stabilized numeric form inputs for venue owners
+- Centralized revalidation handling for path/tag invalidation and Sanity webhook cache refreshes
 
 ### Fixed
 - Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in

--- a/openspec/changes/update-homepage-static-cache/design.md
+++ b/openspec/changes/update-homepage-static-cache/design.md
@@ -1,0 +1,32 @@
+## Context
+The Next.js 16 homepage currently renders without explicit cache directives and lacks a
+webhook-triggered revalidation path. We want a fully static route with long-lived caching
+and on-demand invalidation by tag.
+
+## Goals / Non-Goals
+- Goals:
+  - Ensure the homepage is eligible for the full route cache and static HTML shell.
+  - Add tag-based cache invalidation tied to CMS updates.
+  - Preserve prefetching behavior for faster navigation.
+- Non-Goals:
+  - Redesign homepage UI or change content sources.
+  - Introduce new external caching layers.
+
+## Decisions
+- Decision: Use `use cache`, `cacheLife('days')`, and `cacheTag('home')` in the homepage route.
+  - Why: Aligns with Next.js caching primitives for full route caching and tag invalidation.
+- Decision: Implement a webhook handler/server action that calls `revalidateTag('home')`.
+  - Why: Allows immediate regeneration without shortening cache TTLs.
+
+## Risks / Trade-offs
+- Long cache lifetimes require the webhook to function correctly; stale content can persist
+  if webhooks fail.
+  - Mitigation: Log webhook failures and monitor CMS delivery.
+
+## Migration Plan
+1. Apply cache directives to the homepage and remove legacy dynamic flags.
+2. Add the revalidation handler and document the CMS webhook endpoint.
+3. Verify homepage renders statically and revalidates on tag invalidation.
+
+## Open Questions
+- Which CMS webhook source (Sanity or other) will call the revalidation handler?

--- a/openspec/changes/update-homepage-static-cache/proposal.md
+++ b/openspec/changes/update-homepage-static-cache/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add static homepage caching with tag revalidation
+
+## Why
+The homepage should be fully static with long-lived caching and tag-based revalidation so it
+prefetches quickly while still allowing on-demand updates from CMS changes.
+
+## What Changes
+- Add static cache directives for the homepage route using `use cache` plus cache lifetime/tagging.
+- Ensure the homepage remains eligible for full route cache by removing dynamic flags and APIs.
+- Add a webhook-triggered revalidation handler that calls `revalidateTag('home')`.
+
+## Impact
+- Affected specs: homepage-cache
+- Affected code: `app-next-directory/src/app/page.tsx`,
+  `app-next-directory/src/app/api/**` or server actions for revalidation.

--- a/openspec/changes/update-homepage-static-cache/specs/homepage-cache/spec.md
+++ b/openspec/changes/update-homepage-static-cache/specs/homepage-cache/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+### Requirement: Static homepage cache with tag revalidation
+The system SHALL render the homepage with a static cache entry that uses long-lived freshness
+and supports tag-based revalidation to regenerate the HTML shell on demand.
+
+#### Scenario: Homepage cache configuration
+- **WHEN** the homepage route is rendered
+- **THEN** the route SHALL use `use cache` with `cacheLife('days')` and `cacheTag('home')`
+
+#### Scenario: Tag-based revalidation
+- **WHEN** the CMS webhook handler receives a valid update event
+- **THEN** the system SHALL call `revalidateTag('home')` to invalidate the cached homepage

--- a/openspec/changes/update-homepage-static-cache/tasks.md
+++ b/openspec/changes/update-homepage-static-cache/tasks.md
@@ -1,0 +1,5 @@
+## 1. Implementation
+- [ ] 1.1 Add `use cache` directives and cache lifetime/tagging to the homepage server component.
+- [ ] 1.2 Remove legacy dynamic segment exports or dynamic API usage that would prevent static caching.
+- [ ] 1.3 Add a server action or API route that handles CMS webhook calls and invokes `revalidateTag('home')`.
+- [ ] 1.4 Update tests or add coverage for the revalidation handler as needed.


### PR DESCRIPTION
### Motivation
- Remove duplication and potential inconsistencies by centralizing path/tag revalidation logic into a single helper library.
- Consolidate Sanity webhook tag resolution and listing-specific revalidation into shared utilities to avoid redundant implementations.
- Make it easier to support the homepage static cache proposal that requires calling `revalidateTag('home')` from a webhook handler. 

### Description
- Add `app-next-directory/src/lib/revalidation.ts` which exports `resolveSanityRevalidationTargets`, `revalidateTags`, `revalidatePaths`, and constants like `ALLOWED_REVALIDATION_TAGS`, `TAG_PATTERN`, and `REVALIDATE_ALL_ROUTES`.
- Update `app/api/sanity/webhook/route.ts` to use the shared `SanityWebhookPayload` type plus `resolveSanityRevalidationTargets` and `revalidateTags` to drive tag revalidation.
- Update `app/api/revalidate/route.ts` and `app/api/revalidate-all/route.ts` to import and reuse `ALLOWED_REVALIDATION_TAGS`, `TAG_PATTERN`, `REVALIDATE_ALL_ROUTES`, and `revalidatePaths` instead of duplicating the logic.
- Record the consolidation in `docs/reference/CHANGELOG.md` to note the revalidation handling centralization.

### Testing
- No automated tests were executed as part of this change.
- Existing route/unit tests in the codebase mock `next/cache` and should continue to work with the exported helpers (no test changes were required in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541da63e6c83239e0e0e40c6d35ff8)