### PR TITLE
fix(proxy): redirect unauthorized access to /auth/unauthorized and update e2e tests

### DIFF
--- a/app-next-directory/app/auth/unauthorized/page.tsx
+++ b/app-next-directory/app/auth/unauthorized/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { NeoButton } from '@/components/ui/neo-button';
+import { NeoCard, NeoCardContent, NeoCardHeader, NeoCardTitle } from '@/components/ui/neo-card';
+
+export default function UnauthorizedPage() {
+  return (
+    <PageLayout showFooterNewsletter={false}>
+      <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden px-4 py-16">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-neo-secondary/20 via-transparent to-neo-primary/15" />
+        <NeoCard variant="elevated" className="relative max-w-lg w-full text-center">
+          <NeoCardHeader>
+            <NeoCardTitle className="heading-xl mb-2 text-neo-text-primary">
+              403 - Access Denied
+            </NeoCardTitle>
+          </NeoCardHeader>
+          <NeoCardContent>
+            <p className="text-xl font-semibold text-neo-text-primary mb-6">
+              You don&apos;t have permission to view this page.
+            </p>
+            <NeoButton asChild variant="primary" size="lg">
+              <Link href="/">Go back home</Link>
+            </NeoButton>
+          </NeoCardContent>
+        </NeoCard>
+      </section>
+    </PageLayout>
+  );
+}

--- a/app-next-directory/proxy.ts
+++ b/app-next-directory/proxy.ts
@@ -102,7 +102,7 @@ export async function proxy(request: NextRequest) {
       if (isAdminRoute) {
         // Only admin and superAdmin can access admin routes
         if (userRole !== 'admin' && userRole !== 'superAdmin') {
-          const forbiddenUrl = new URL('/403', request.nextUrl.origin || request.url);
+          const forbiddenUrl = new URL('/auth/unauthorized', request.nextUrl.origin || request.url);
           return withSecurityHeaders(NextResponse.redirect(forbiddenUrl));
         }
       }
@@ -114,7 +114,7 @@ export async function proxy(request: NextRequest) {
         const canManageListings =
           userRole === 'venueOwner' || userRole === 'admin' || userRole === 'superAdmin';
         if (!canManageListings) {
-          const forbiddenUrl = new URL('/403', request.nextUrl.origin || request.url);
+          const forbiddenUrl = new URL('/auth/unauthorized', request.nextUrl.origin || request.url);
           return withSecurityHeaders(NextResponse.redirect(forbiddenUrl));
         }
       }

--- a/app-next-directory/tests/e2e/admin-dashboard.spec.ts
+++ b/app-next-directory/tests/e2e/admin-dashboard.spec.ts
@@ -17,6 +17,7 @@ test.describe('Admin Dashboard Integration', () => {
 
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
+      await expect(page).toHaveURL(/\/auth\/unauthorized/);
       await expect(page.getByRole('heading', { name: /403 - Access Denied/i })).toBeVisible({
         timeout: 10000,
       });
@@ -34,6 +35,7 @@ test.describe('Admin Dashboard Integration', () => {
 
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
+      await expect(page).toHaveURL(/\/auth\/unauthorized/);
       await expect(page.getByRole('heading', { name: /403 - Access Denied/i })).toBeVisible({
         timeout: 10000,
       });

--- a/app-next-directory/tests/e2e/listing-management.spec.ts
+++ b/app-next-directory/tests/e2e/listing-management.spec.ts
@@ -23,10 +23,10 @@ test.describe('Listing Management E2E', () => {
 
       // Try to access admin routes
       await page.goto('/admin/dashboard');
-      await expect(page).toHaveURL(/\/403/);
+      await expect(page).toHaveURL(/\/auth\/unauthorized/);
 
       await page.goto('/admin/listings');
-      await expect(page).toHaveURL(/\/403/);
+      await expect(page).toHaveURL(/\/auth\/unauthorized/);
 
       // Try to access moderation API
       const response = await TestHelpers.makeAuthenticatedRequest(page, '/api/admin/moderation', {
@@ -119,7 +119,7 @@ test.describe('Listing Management E2E', () => {
 
       // Attempt to edit
       await page.goto(`/dashboard/listings/edit/${listingId}`).catch(() => undefined);
-      await expect(page).toHaveURL(/\/403/);
+      await expect(page).toHaveURL(/\/auth\/unauthorized/);
 
       // Attempt to delete
       const deleteResponse = await TestHelpers.makeAuthenticatedRequest(

--- a/app-next-directory/tests/e2e/rbac.e2e.spec.ts
+++ b/app-next-directory/tests/e2e/rbac.e2e.spec.ts
@@ -13,7 +13,7 @@ test.describe('RBAC (Playwright)', () => {
 
     const res = await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded' });
 
-    // Accept either a 401/403 status, an explicit /403 page, or a redirect to a signin/login page
+    // Accept either a 401/403 status, an explicit unauthorized page, or a redirect to a signin/login page
     const status = res?.status() ?? 0;
     if ([401, 403].includes(status)) {
       expect([401, 403]).toContain(status);
@@ -26,7 +26,7 @@ test.describe('RBAC (Playwright)', () => {
       return;
     }
 
-    await expect(page).toHaveURL(/\/(403|login|api\/auth\/signin)(?:[?#].*)?$/);
+    await expect(page).toHaveURL(/\/(auth\/unauthorized|login|api\/auth\/signin)(?:[?#].*)?$/);
   });
 
   test('venue owner cannot access admin routes', async ({ page }) => {
@@ -47,7 +47,7 @@ test.describe('RBAC (Playwright)', () => {
       expect(current).toContain('error=unauthorized_access');
       return;
     }
-    await expect(page).toHaveURL(/\/(403|login|api\/auth\/signin)(?:[?#].*)?$/);
+    await expect(page).toHaveURL(/\/(auth\/unauthorized|login|api\/auth\/signin)(?:[?#].*)?$/);
   });
   test('admin can access admin routes', async ({ page }) => {
     await loginAs(

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensured admin route middleware reads session tokens from requests and redirects non-admins to sign-in
+- Redirected unauthorized access attempts to the dedicated /auth/unauthorized page
 - Stacked login/signup panels on smaller screens and limited social sign-in to Google-only setup
 - Restored listing editing for venue owners and admins by aligning managed listing APIs with Sanity ownership
 - Aligned admin listing stats and table filters with moderation status and featured flags to match published featured counts


### PR DESCRIPTION
### Motivation
- The global middleware was redirecting unauthorized users to the home/`/403` route instead of a dedicated unauthorized page, causing inconsistent UX and test expectations.
- Provide a canonical, user-facing `/auth/unauthorized` page so middleware and client-side auth helpers converge on a single location for access-denied flows.
- Align Playwright tests with the new route so e2e assertions reflect actual app behavior.

### Description
- Updated `app-next-directory/proxy.ts` to redirect admin and listing authorization failures to `/auth/unauthorized` instead of `/403`.
- Added a new Next.js route `app-next-directory/app/auth/unauthorized/page.tsx` that mirrors the existing 403 content and CTA.
- Updated Playwright e2e tests to expect `/auth/unauthorized` in `admin-dashboard.spec.ts`, `listing-management.spec.ts`, and `rbac.e2e.spec.ts`.
- Recorded the change in `docs/reference/CHANGELOG.md`.

### Testing
- Dev server was started with `pnpm --filter app-next-directory dev` to smoke-check the app boot (server launched successfully).
- A Playwright screenshot/visit of `/auth/unauthorized` was attempted but the headless Chromium process crashed in this environment, so UI screenshots could not be captured.
- No full automated Jest or Playwright test suites were executed as part of this change in this run.
- All changes were committed; please run `pnpm test:e2e` and `pnpm test:unit` in CI to validate the updated routes and assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69543170195c832390710663bbc126b4)