### PR TITLE
fix: align admin routing to /admin

### DIFF
--- a/app-next-directory/app/admin/AdminNavigation.tsx
+++ b/app-next-directory/app/admin/AdminNavigation.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 
 const NAV_ITEMS = [
   {
-    href: '/admin/dashboard',
+    href: '/admin',
     label: 'Dashboard',
     description: 'Overview and status',
     icon: LayoutDashboard,

--- a/app-next-directory/app/admin/__tests__/layout.test.tsx
+++ b/app-next-directory/app/admin/__tests__/layout.test.tsx
@@ -16,7 +16,7 @@ const redirectMock = jest.fn();
 
 jest.mock('next/navigation', () => ({
   redirect: (...args: unknown[]) => redirectMock(...args),
-  usePathname: jest.fn(() => '/admin/dashboard'),
+  usePathname: jest.fn(() => '/admin'),
 }));
 
 const mockAuth = jest.requireMock('@/lib/auth').auth as jest.Mock;
@@ -46,7 +46,7 @@ describe('Admin layout', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /dashboard/i })).toHaveAttribute(
       'href',
-      '/admin/dashboard'
+      '/admin'
     );
     expect(screen.getByRole('link', { name: /back to site/i })).toHaveAttribute('href', '/');
     expect(screen.getByTestId('layout-child')).toBeInTheDocument();

--- a/app-next-directory/app/api/preview/exit/__tests__/route.test.ts
+++ b/app-next-directory/app/api/preview/exit/__tests__/route.test.ts
@@ -221,14 +221,12 @@ describe('Preview Exit API - GET /api/preview/exit', () => {
     });
 
     it('should handle nested path redirect', async () => {
-      const request = new Request(
-        'http://localhost/api/preview/exit?redirect=/admin/dashboard/stats'
-      );
+      const request = new Request('http://localhost/api/preview/exit?redirect=/admin/stats');
 
       const response = await GET(request);
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toContain('/admin/dashboard/stats');
+      expect(response.headers.get('location')).toContain('/admin/stats');
     });
   });
 

--- a/app-next-directory/src/components/layout/Header.tsx
+++ b/app-next-directory/src/components/layout/Header.tsx
@@ -185,7 +185,7 @@ export function Header(): React.JSX.Element {
                     {isAdmin && (
                       <DropdownMenu.Item asChild>
                         <Link
-                          href="/admin/dashboard"
+                          href="/admin"
                           className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neo-text-primary outline-none transition data-[highlighted]:bg-neo-primary/10"
                         >
                           <LayoutDashboard size={16} aria-hidden="true" />

--- a/app-next-directory/src/components/layout/__tests__/Header.test.tsx
+++ b/app-next-directory/src/components/layout/__tests__/Header.test.tsx
@@ -536,7 +536,7 @@ describe('Header', () => {
       await user.click(screen.getByRole('button', { name: /open account menu/i }));
 
       await waitFor(() => {
-        const adminLink = document.querySelector('a[href="/admin/dashboard"]');
+        const adminLink = document.querySelector('a[href="/admin"]');
         expect(adminLink).toBeInTheDocument();
         expect(adminLink?.textContent).toMatch(/admin dashboards/i);
       });
@@ -735,7 +735,7 @@ describe('Header', () => {
 
       await waitFor(() => {
         const dashboardLink = document.querySelector('a[href="/dashboard"]');
-        const adminLink = document.querySelector('a[href="/admin/dashboard"]');
+        const adminLink = document.querySelector('a[href="/admin"]');
         const profileLink = document.querySelector('a[href="/profile"]');
         expect(profileLink).toBeInTheDocument();
         expect(dashboardLink).not.toBeInTheDocument();

--- a/app-next-directory/src/tests/mocks/factories.test.ts
+++ b/app-next-directory/src/tests/mocks/factories.test.ts
@@ -48,10 +48,10 @@ describe('Mock Factories', () => {
     });
 
     it('should handle protected routes', () => {
-      const mockRequest = makeMockRequest('/admin/dashboard');
+      const mockRequest = makeMockRequest('/admin');
 
-      expect(mockRequest.nextUrl.pathname).toBe('/admin/dashboard');
-      expect(mockRequest.url).toContain('/admin/dashboard');
+      expect(mockRequest.nextUrl.pathname).toBe('/admin');
+      expect(mockRequest.url).toContain('/admin');
     });
 
     it('should handle paths with multiple segments', () => {

--- a/app-next-directory/tests/e2e/admin-dashboard.spec.ts
+++ b/app-next-directory/tests/e2e/admin-dashboard.spec.ts
@@ -10,7 +10,7 @@ test.describe('Admin Dashboard Integration', () => {
 
       // Try to navigate to admin dashboard - should be redirected
       try {
-        await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'load', timeout: 15000 });
+        await page.goto(`${BASE_URL}/admin`, { waitUntil: 'load', timeout: 15000 });
       } catch {
         // Redirects can cause net::ERR_ABORTED; that's expected for forbidden routes
       }
@@ -27,7 +27,7 @@ test.describe('Admin Dashboard Integration', () => {
 
       // Try to navigate to admin dashboard - should be redirected
       try {
-        await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'load', timeout: 15000 });
+        await page.goto(`${BASE_URL}/admin`, { waitUntil: 'load', timeout: 15000 });
       } catch {
         // Redirects can cause net::ERR_ABORTED; that's expected for forbidden routes
       }
@@ -41,7 +41,7 @@ test.describe('Admin Dashboard Integration', () => {
 
     test('unauthenticated user is redirected to login', async ({ page }) => {
       await page
-        .goto(`${BASE_URL}/admin/dashboard`, {
+        .goto(`${BASE_URL}/admin`, {
           waitUntil: 'load',
           timeout: 15000,
         })

--- a/app-next-directory/tests/e2e/listing-management.spec.ts
+++ b/app-next-directory/tests/e2e/listing-management.spec.ts
@@ -22,7 +22,7 @@ test.describe('Listing Management E2E', () => {
       await TestHelpers.loginAsUser(page);
 
       // Try to access admin routes
-      await page.goto('/admin/dashboard');
+      await page.goto('/admin');
       await expect(page).toHaveURL(/\/403/);
 
       await page.goto('/admin/listings');

--- a/app-next-directory/tests/e2e/rbac.e2e.spec.ts
+++ b/app-next-directory/tests/e2e/rbac.e2e.spec.ts
@@ -11,7 +11,7 @@ test.describe('RBAC (Playwright)', () => {
       process.env.E2E_USER_PASSWORD ?? 'TestSecurePass123!'
     );
 
-    const res = await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded' });
+    const res = await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded' });
 
     // Accept either a 401/403 status, an explicit /403 page, or a redirect to a signin/login page
     const status = res?.status() ?? 0;
@@ -36,7 +36,7 @@ test.describe('RBAC (Playwright)', () => {
       process.env.E2E_VENUE_OWNER_PASSWORD ?? 'TestSecurePass123!'
     );
 
-    const res = await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded' });
+    const res = await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded' });
     const status = res?.status() ?? 0;
     if ([401, 403].includes(status)) {
       expect([401, 403]).toContain(status);
@@ -56,7 +56,7 @@ test.describe('RBAC (Playwright)', () => {
       process.env.E2E_ADMIN_PASSWORD ?? 'TestSecurePass123!'
     );
 
-    const res = await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded' });
+    const res = await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded' });
 
     // If the server responded with a 401/403 that's unexpected for an admin
     const status = res?.status() ?? 0;

--- a/app-next-directory/tests/e2e/security/security.spec.ts
+++ b/app-next-directory/tests/e2e/security/security.spec.ts
@@ -31,7 +31,7 @@ const createUrlPattern = (url: string) => new RegExp(`.*${escapeForRegex(url)}`)
 const TEST_CONFIG = {
   urls: {
     home: process.env.TEST_HOME_URL ?? '/',
-    adminDashboard: process.env.TEST_ADMIN_DASHBOARD_URL ?? '/admin/dashboard',
+    adminDashboard: process.env.TEST_ADMIN_DASHBOARD_URL ?? '/admin',
     signin: process.env.TEST_SIGNIN_URL ?? '/auth/login',
     signup: process.env.TEST_SIGNUP_URL ?? '/auth/signup',
     dashboard: process.env.TEST_DASHBOARD_URL ?? '/dashboard',

--- a/app-next-directory/tests/utils/test-utils.ts
+++ b/app-next-directory/tests/utils/test-utils.ts
@@ -123,7 +123,7 @@ export const test = base.extend<{ authenticatedPage: Page; adminPage: Page }>({
     await use(page);
   },
   adminPage: async ({ page }, use) => {
-    await loginAs(page, 'admin', { redirectTo: '/admin/dashboard' });
+    await loginAs(page, 'admin', { redirectTo: '/admin' });
     await use(page);
   },
 });
@@ -200,7 +200,7 @@ export const TestHelpers = {
   },
 
   async loginAsAdmin(page: Page, email?: string, password?: string) {
-    await loginByRole(page, 'admin', '/admin/dashboard', email, password);
+    await loginByRole(page, 'admin', '/admin', email, password);
   },
 
   async createListing(page: Page, data: any = {}) {

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned admin listing stats and table filters with moderation status and featured flags to match published featured counts
 - Guarded contact form emails against header injection payloads during client-side validation
 - Avoided server-provided featured listings during E2E runs so network retry flows can exercise fetch resilience
+- Aligned admin redirects, navigation links, and E2E helpers to use the /admin route
 
 ## [0.1.3] - 2025-01-XX
 


### PR DESCRIPTION
### Motivation
- Resolve mismatch between the app file structure (admin at `/admin`) and code/tests that referenced `/admin/dashboard`.
- Prevent E2E timeouts and 404s caused by hard-coded redirects to a non-existent `/admin/dashboard` path.
- Keep navigation links, preview redirects, and authentication helpers consistent with the current admin route.

### Description
- Replaced occurrences of `/admin/dashboard` with `/admin` in navigation and account menu components including `app/admin/AdminNavigation.tsx` and `src/components/layout/Header.tsx`.
- Updated Playwright helpers in `tests/utils/test-utils.ts` to redirect to `/admin` and changed `TestHelpers.loginAsAdmin` and the `adminPage` fixture accordingly.
- Aligned E2E specs and unit tests to the new route in `tests/e2e/*`, `app/api/preview/exit/__tests__/route.test.ts`, `src/tests/mocks/factories.test.ts`, and component tests under `src/components/layout/__tests__/`.
- Added a changelog note in `docs/reference/CHANGELOG.md` to document the routing alignment.

### Testing
- No automated tests were executed as part of this change.
- The change updates unit tests and Playwright E2E specs which should be validated by running `pnpm test:unit` and `pnpm test:e2e` in CI or locally.
- Recommend running the full test matrix (`pnpm test:unit`, `pnpm test:integration`, `pnpm test:e2e`) and `pnpm test:coverage` before merging to confirm everything passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954318e7cf88323baad9b2c41261185)